### PR TITLE
Add CI to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+go-deploy
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,3 +14,6 @@
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+
+# Tools
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+run:
+  deadline: 3m
+  modules-download-mode: vendor
+  skip-dirs:
+    - client
+    - models
+
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - unconvert
+    - unused
+    - unparam
+    - varcheck
+    - vet
+    - gosec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+dist: xenial
+sudo: required
+services:
+  - docker
+language: go
+
+env:
+  global: GOFLAGS=-mod=vendor
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+  include:
+    - go: "1.13.x"
+      name: "Code Lint"
+      script: make lint
+    - go: "1.13.x"
+      name: "Code UnitTest"
+      script: make test
+    - go: "1.13.x"
+      name: "Generated Code is Current"
+      script: make gen && git diff --quiet
+
+install:
+  - make tools
+  - go mod vendor
+
+# branches:
+#   only:
+#     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ services:
 language: go
 
 env:
-  global: GOFLAGS=-mod=vendor
+  global:
+    - GOFLAGS=-mod=vendor
 
 matrix:
   fast_finish: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,8 +25,7 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 lint:
-	@./bin/golangci-lint run ./$(PKG_NAME)/...
-	@docker run -v $(CUR_DIR):/src bflad/tfproviderlint:0.14.0 ./...
+	@./bin/golangci-lint run
 
 tools:
 	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.24.0

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,10 +13,10 @@ gen:
 	bin/swagger generate client
 
 test: fmtcheck
-	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
+	go test $(TEST) -timeout=120s -parallel=4
 
-testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+testapi: fmtcheck
+	go test $(TEST) -timeout=120s -parallel=4 -tags=api
 
 fmt:
 	gofmt -s -w .
@@ -31,4 +31,4 @@ tools:
 	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.24.0
 	@scripts/install-swagger.sh
 
-.PHONY: build gen test testacc fmt fmtcheck lint tools
+.PHONY: build gen test testacc fmt fmtcheck lint tools testapi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,35 @@
+TEST?=./...
+GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+PKG_NAME=aptible
+TEST_COUNT?=1
+CUR_DIR = $(shell echo "${PWD}")
+
+default: build
+
+build: fmtcheck
+	go install
+
+gen:
+	bin/swagger generate client
+
+test: fmtcheck
+	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
+
+testacc: fmtcheck
+	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+
+fmt:
+	gofmt -s -w .
+
+fmtcheck:
+	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+
+lint:
+	@./bin/golangci-lint run ./$(PKG_NAME)/...
+	@docker run -v $(CUR_DIR):/src bflad/tfproviderlint:0.14.0 ./...
+
+tools:
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.24.0
+	@scripts/install-swagger.sh
+
+.PHONY: build gen test testacc fmt fmtcheck lint tools

--- a/aptible/api_required_test.go
+++ b/aptible/api_required_test.go
@@ -1,0 +1,42 @@
+// +build api
+
+// These tests call SetUpClient and require a valid client
+// setup for API access. By default they are skipped on CI
+
+package aptible
+
+import (
+	"testing"
+)
+
+func TestWaitForOperation(t *testing.T) {
+	var tests = []struct {
+		name        string
+		operationID int64
+		deleted     bool
+		errored     bool
+	}{
+		{"test_404", 0, true, false},
+		// Add other test cases if we need in the future
+	}
+
+	for _, tc := range tests {
+		c, err := SetUpClient()
+		if err != nil {
+			t.Errorf("Unable to set up client due to error. \nERROR -- %s", err)
+		}
+		testName := tc.name
+		t.Run(testName, func(t *testing.T) {
+
+			deleted, err := c.WaitForOperation(tc.operationID)
+
+			if deleted != tc.deleted {
+				t.Errorf("Input: %d should have resulted in a 404.", tc.operationID)
+			}
+
+			if (err != nil) != tc.errored {
+				t.Errorf("Input: %d caused error: %s", tc.operationID, err)
+			}
+		})
+	}
+}

--- a/aptible/app.go
+++ b/aptible/app.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )

--- a/aptible/client.go
+++ b/aptible/client.go
@@ -52,11 +52,8 @@ func GetHost() (string, error) {
 	}
 	host = strings.Trim(host, " ")
 
-	if strings.HasPrefix(host, "http://") {
-		host = host[7:]
-	} else if strings.HasPrefix(host, "https://") {
-		host = host[8:]
-	}
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
 
 	if !validHost(host) {
 		return "", fmt.Errorf("[ERROR] Host must be of the form xxx.xxx.com. Inputted host: %s", host)

--- a/aptible/client_test.go
+++ b/aptible/client_test.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -24,7 +23,7 @@ func TestGetHost(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		testName := fmt.Sprintf("%s", tc.host)
+		testName := tc.host
 		t.Run(testName, func(t *testing.T) {
 
 			_ = os.Setenv("APTIBLE_API_ROOT_URL", tc.host)

--- a/aptible/configuration.go
+++ b/aptible/configuration.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 )
 

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -1,7 +1,9 @@
 package aptible
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )
@@ -77,16 +79,15 @@ func (c *Client) GetDatabase(databaseID int64) (Database, error) {
 	params := operations.NewGetDatabasesIDParams().WithID(databaseID)
 	resp, err := c.Client.Operations.GetDatabasesID(params, c.Token)
 	if err != nil {
-		switch err.(type) {
-		case *operations.GetDatabasesIDDefault:
-			if err.(*operations.GetDatabasesIDDefault).Code() == 404 {
+		var e *operations.GetDatabasesIDDefault
+		if errors.As(err, &e) {
+			if e.Code() == 404 {
 				err = nil
 			}
 			database.Deleted = true
 			return database, err
-		default:
-			return Database{}, err
 		}
+		return Database{}, err
 	}
 
 	connectionUrl := resp.Payload.ConnectionURL

--- a/aptible/database_replica.go
+++ b/aptible/database_replica.go
@@ -40,9 +40,15 @@ func (c *Client) CreateReplica(attrs ReplicateAttrs) (Database, error) {
 	fmt.Println("The replicate operation has started.")
 
 	repl, err := c.GetReplicaFromHandle(attrs.DatabaseID, attrs.ReplicaHandle)
+	if err != nil {
+		return Database{}, err
+	}
 	for repl == nil {
-		time.Sleep(5)
+		time.Sleep(5 * time.Second)
 		repl, err = c.GetReplicaFromHandle(attrs.DatabaseID, attrs.ReplicaHandle)
+		if err != nil {
+			return Database{}, err
+		}
 	}
 
 	replicaID := repl.ID

--- a/aptible/disk.go
+++ b/aptible/disk.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 )
 

--- a/aptible/endpoints.go
+++ b/aptible/endpoints.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )

--- a/aptible/helpers_test.go
+++ b/aptible/helpers_test.go
@@ -4,38 +4,6 @@ import (
 	"testing"
 )
 
-func TestWaitForOperation(t *testing.T) {
-	var tests = []struct {
-		name        string
-		operationID int64
-		deleted     bool
-		errored     bool
-	}{
-		{"test_404", 0, true, false},
-		// Add other test cases if we need in the future
-	}
-
-	for _, tc := range tests {
-		c, err := SetUpClient()
-		if err != nil {
-			t.Errorf("Unable to set up client due to error. \nERROR -- %s", err)
-		}
-		testName := tc.name
-		t.Run(testName, func(t *testing.T) {
-
-			deleted, err := c.WaitForOperation(tc.operationID)
-
-			if deleted != tc.deleted {
-				t.Errorf("Input: %d should have resulted in a 404.", tc.operationID)
-			}
-
-			if (err != nil) != tc.errored {
-				t.Errorf("Input: %d caused error: %s", tc.operationID, err)
-			}
-		})
-	}
-}
-
 func TestGetIDFromHref(t *testing.T) {
 	var tests = []struct {
 		name     string
@@ -43,9 +11,9 @@ func TestGetIDFromHref(t *testing.T) {
 		expected int64
 		errored  bool
 	}{
-		{"test_vanilla", "https://api-rachel.aptible-sandbox.com/disks/46", 46, false},
-		{"test_conversion_err", "https://api-rachel.aptible-sandbox.com/disks/str", 0, true},
-		{"test_too_short", "https://api-rachel.aptible-sandbox.com/2", 0, true},
+		{"test_vanilla", "https://api.aptible.com/disks/46", 46, false},
+		{"test_conversion_err", "https://api.aptible.com/disks/str", 0, true},
+		{"test_too_short", "https://api.aptible.com/2", 0, true},
 		// Add other test cases if we need in the future
 	}
 

--- a/aptible/helpers_test.go
+++ b/aptible/helpers_test.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -21,7 +20,7 @@ func TestWaitForOperation(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unable to set up client due to error. \nERROR -- %s", err)
 		}
-		testName := fmt.Sprintf("%s", tc.name)
+		testName := tc.name
 		t.Run(testName, func(t *testing.T) {
 
 			deleted, err := c.WaitForOperation(tc.operationID)
@@ -51,7 +50,7 @@ func TestGetIDFromHref(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		testName := fmt.Sprintf("%s", tc.name)
+		testName := tc.name
 		t.Run(testName, func(t *testing.T) {
 
 			id, err := GetIDFromHref(tc.href)
@@ -86,7 +85,7 @@ func TestMakeStringSlice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		testName := fmt.Sprintf("%s", tc.name)
+		testName := tc.name
 		t.Run(testName, func(t *testing.T) {
 
 			slice, err := MakeStringSlice(tc.interfaceSlice)

--- a/aptible/resolve_handle.go
+++ b/aptible/resolve_handle.go
@@ -1,6 +1,7 @@
 package aptible
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aptible/go-deploy/client/operations"
@@ -58,15 +59,13 @@ func (c *Client) GetDatabaseIDFromHandle(accountID int64, handle string) (int64,
 	params := operations.NewGetAccountsAccountIDDatabasesParams().WithAccountID(accountID)
 	response, err := c.Client.Operations.GetAccountsAccountIDDatabases(params, c.Token)
 	if err != nil {
-		switch err.(type) {
-		case *operations.GetAccountsAccountIDDatabasesDefault:
-			if err.(*operations.GetAccountsAccountIDDatabasesDefault).Code() == 404 {
+		var e *operations.GetAccountsAccountIDDatabasesDefault
+		if errors.As(err, &e) {
+			if e.Code() == 404 {
 				deleted = true
 			}
-			return 0, deleted, err
-		default:
-			return 0, deleted, err
 		}
+		return 0, deleted, err
 	}
 
 	if response.Payload.TotalCount == nil {
@@ -101,15 +100,13 @@ func (c *Client) GetDatabaseIDFromHandle(accountID int64, handle string) (int64,
 		params := operations.NewGetAccountsAccountIDDatabasesParams().WithAccountID(accountID).WithPage(&page)
 		response, err = c.Client.Operations.GetAccountsAccountIDDatabases(params, c.Token)
 		if err != nil {
-			switch err.(type) {
-			case *operations.GetAccountsAccountIDDatabasesDefault:
-				if err.(*operations.GetAccountsAccountIDDatabasesDefault).Code() == 404 {
+			var e *operations.GetAccountsAccountIDDatabasesDefault
+			if errors.As(err, &e) {
+				if e.Code() == 404 {
 					deleted = true
 				}
-				return 0, deleted, err
-			default:
-				return 0, deleted, err
 			}
+			return 0, deleted, err
 		}
 	}
 	return 0, deleted, fmt.Errorf("there are no databases with handle: %s", handle)

--- a/aptible/service.go
+++ b/aptible/service.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )

--- a/aptible/tokens.go
+++ b/aptible/tokens.go
@@ -30,7 +30,7 @@ func GetToken() (string, error) {
 	// Contains tokens from the tokens.json file.
 	var tokens map[string]string
 	if err := json.Unmarshal(dat, &tokens); err != nil {
-		panic(err)
+		return "", err
 	}
 
 	// Gets auth server

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Check gofmt
+echo "==> Checking that code complies with gofmt requirements..."
+gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l -s)
+if [[ -n ${gofmt_files} ]]; then
+    echo 'gofmt needs running on the following files:'
+    echo "${gofmt_files}"
+    echo "You can use the command: \`make fmt\` to reformat code."
+    exit 1
+fi
+
+exit 0

--- a/scripts/install-swagger.sh
+++ b/scripts/install-swagger.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+download_url=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/tags/v0.21.0 | jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url')
+curl -o bin/swagger -L'#' "$download_url"
+chmod +x bin/swagger


### PR DESCRIPTION
Part of https://aptible.atlassian.net/browse/DP-299

Adds Travis testing for:

1. It passes linting
2. It's `go fmt`'d and our unit tests pass
3. The generated code is up to date

This uses the new makefile so that you can create the tests locally with:

1. `make lint`
2. `make test`
3. `make gen`

The second commit updates the code to fix linter issues.

Travis will skip tests that require making valid API calls. Those are available via `make testapi` for local testing with appropriate API values set in environment variables.