### PR TITLE
Deprovision, not destroy databases

### DIFF
--- a/aptible/database.go
+++ b/aptible/database.go
@@ -18,7 +18,7 @@ type Database struct {
 	Type             string
 	EnvironmentID    int64
 	InitializeFromID int64
-	Service		     Service
+	Service          Service
 }
 
 type DBUpdates struct {

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -188,8 +188,8 @@ func (c *Client) DeleteDatabase(databaseID int64) error {
 	request := models.AppRequest23{
 		Type: &requestType,
 	}
-	provisionParams := operations.NewPostDatabasesDatabaseIDOperationsParams().WithDatabaseID(databaseID).WithAppRequest(&request)
-	op, err := c.Client.Operations.PostDatabasesDatabaseIDOperations(provisionParams, c.Token)
+	deprovisionParams := operations.NewPostDatabasesDatabaseIDOperationsParams().WithDatabaseID(databaseID).WithAppRequest(&request)
+	op, err := c.Client.Operations.PostDatabasesDatabaseIDOperations(deprovisionParams, c.Token)
 	if err != nil {
 		return err
 	}

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -184,8 +184,17 @@ func (c *Client) UpdateDatabase(databaseID int64, updates DBUpdates) error {
 }
 
 func (c *Client) DeleteDatabase(databaseID int64) error {
-	params := operations.NewDeleteDatabasesIDParams().WithID(databaseID)
-	_, err := c.Client.Operations.DeleteDatabasesID(params, c.Token)
+	requestType := "deprovision"
+	request := models.AppRequest23{
+		Type: &requestType,
+	}
+	provisionParams := operations.NewPostDatabasesDatabaseIDOperationsParams().WithDatabaseID(databaseID).WithAppRequest(&request)
+	op, err := c.Client.Operations.PostDatabasesDatabaseIDOperations(provisionParams, c.Token)
+	if err != nil {
+		return err
+	}
+	operationID := *op.Payload.ID
+	_, err = c.WaitForOperation(operationID)
 	return err
 }
 


### PR DESCRIPTION
And wait for operations, don't poll. For some reason polling was going too fast. Waiting is probably the right way to do it anyway.