### PR TITLE
Add check for nil pointer to service lookup

### DIFF
--- a/aptible/service.go
+++ b/aptible/service.go
@@ -127,13 +127,16 @@ func (c *Client) GetServiceForAppByName(appID int64, serviceName string) (Servic
 
 	for _, service := range services {
 		if service.ProcessType == serviceName {
-			return Service{
-				ID:                     service.ID,
-				ContainerCount:         service.ContainerCount,
-				ContainerMemoryLimitMb: *service.ContainerMemoryLimitMb,
-				ProcessType:            service.ProcessType,
-				Command:                service.Command,
-			}, nil
+			s := Service{
+				ID:             service.ID,
+				ContainerCount: service.ContainerCount,
+				ProcessType:    service.ProcessType,
+				Command:        service.Command,
+			}
+			if service.ContainerMemoryLimitMb != nil {
+				s.ContainerMemoryLimitMb = *service.ContainerMemoryLimitMb
+			}
+			return s, nil
 		}
 	}
 


### PR DESCRIPTION
Per conversation at: https://aptible.slack.com/archives/CS79D76Q4/p1595972996002500

Adds a check for a nil pointer before dereferencing the pointer for a services `ContainerMemoryLimitMb`. That field could be empty if the stack default is being used.