### PR TITLE
Clearer errors when the tokens file is invalid

### DIFF
--- a/aptible/tokens.go
+++ b/aptible/tokens.go
@@ -19,18 +19,18 @@ func GetToken() (string, error) {
 
 	home, err := homedir.Dir()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Your token is invalid. Are you logged in? Error: %v", err.Error())
 	}
 
 	dat, err := ioutil.ReadFile(filepath.Join(home, ".aptible", "tokens.json"))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Your token is invalid. Are you logged in? Error: %v", err.Error())
 	}
 
 	// Contains tokens from the tokens.json file.
 	var tokens map[string]string
 	if err := json.Unmarshal(dat, &tokens); err != nil {
-		return "", err
+		return "", fmt.Errorf("Your token is invalid. Are you logged in? Error: %v", err.Error())
 	}
 
 	// Gets auth server
@@ -45,5 +45,5 @@ func GetToken() (string, error) {
 		return token, nil
 	}
 
-	return "", fmt.Errorf("no token found for %s", auth)
+	return "", fmt.Errorf("No token can be found for %v. Are you logged in?", auth)
 }


### PR DESCRIPTION
This handles the invalid token file format issue outlined here: https://github.com/aptible/docs/pull/190#discussion_r458911368

Making @UserNotFound the reviewer since it's a simple change, and he's the one that requested it. 

Here's what it looks like in action:

```
# No file
$ go run whatever.go
Your token is invalid. Are you logged in? Error: open /Users/ashley/.aptible/tokens.json: no such file or directory

# Invalid file
$ go run whatever.go
Your token is invalid. Are you logged in? Error: unexpected end of JSON input

# No creds in the file
$ go run whatever.go
No token can be found for https://auth.aptible.com. Are you logged in?
```