### PR TITLE
Delete endpoints by using deprovision operations

### DIFF
--- a/aptible/endpoints.go
+++ b/aptible/endpoints.go
@@ -203,8 +203,16 @@ func (c *Client) UpdateEndpoint(endpointID int64, up EndpointUpdates) error {
 
 // DeleteEndpoint() deletes the endpoint.
 func (c *Client) DeleteEndpoint(endpointID int64) error {
-	params := operations.NewDeleteVhostsIDParams().WithID(endpointID)
-	_, err := c.Client.Operations.DeleteVhostsID(params, c.Token)
+	requestType := "deprovision"
+	operationRequest := models.AppRequest26{Type: &requestType}
+	operationParams := operations.NewPostVhostsVhostIDOperationsParams().WithVhostID(endpointID).WithAppRequest(&operationRequest)
+	op, err := c.Client.Operations.PostVhostsVhostIDOperations(operationParams, c.Token)
+	if err != nil {
+		return err
+	}
+
+	operationID := *op.Payload.ID
+	_, err = c.WaitForOperation(operationID)
 	return err
 }
 

--- a/models/app_request21.go
+++ b/models/app_request21.go
@@ -42,6 +42,9 @@ type AppRequest21 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request22.go
+++ b/models/app_request22.go
@@ -42,6 +42,9 @@ type AppRequest22 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request23.go
+++ b/models/app_request23.go
@@ -42,6 +42,9 @@ type AppRequest23 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request24.go
+++ b/models/app_request24.go
@@ -42,6 +42,9 @@ type AppRequest24 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request25.go
+++ b/models/app_request25.go
@@ -42,6 +42,9 @@ type AppRequest25 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request26.go
+++ b/models/app_request26.go
@@ -42,6 +42,9 @@ type AppRequest26 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request27.go
+++ b/models/app_request27.go
@@ -42,6 +42,9 @@ type AppRequest27 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request28.go
+++ b/models/app_request28.go
@@ -42,6 +42,9 @@ type AppRequest28 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request29.go
+++ b/models/app_request29.go
@@ -42,6 +42,9 @@ type AppRequest29 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/app_request30.go
+++ b/models/app_request30.go
@@ -42,6 +42,9 @@ type AppRequest30 struct {
 	// disk size
 	DiskSize int64 `json:"disk_size,omitempty"`
 
+	// docker ref
+	DockerRef string `json:"docker_ref,omitempty"`
+
 	// env
 	Env interface{} `json:"env,omitempty"`
 

--- a/models/inline_response2004_embedded_backups.go
+++ b/models/inline_response2004_embedded_backups.go
@@ -34,6 +34,9 @@ type InlineResponse2004EmbeddedBackups struct {
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
+	// database handle
+	DatabaseHandle string `json:"database_handle,omitempty"`
+
 	// id
 	ID int64 `json:"id,omitempty"`
 

--- a/models/inline_response2005.go
+++ b/models/inline_response2005.go
@@ -41,6 +41,10 @@ type InlineResponse2005 struct {
 	// Required: true
 	CreatedAt *string `json:"created_at"`
 
+	// database handle
+	// Required: true
+	DatabaseHandle *string `json:"database_handle"`
+
 	// id
 	// Required: true
 	ID *int64 `json:"id"`
@@ -75,6 +79,10 @@ func (m *InlineResponse2005) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateCreatedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDatabaseHandle(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -158,6 +166,15 @@ func (m *InlineResponse2005) validateAwsSnapshotID(formats strfmt.Registry) erro
 func (m *InlineResponse2005) validateCreatedAt(formats strfmt.Registry) error {
 
 	if err := validate.Required("created_at", "body", m.CreatedAt); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *InlineResponse2005) validateDatabaseHandle(formats strfmt.Registry) error {
+
+	if err := validate.Required("database_handle", "body", m.DatabaseHandle); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We were deleting the endpoint object without calling a deprovision
operation. This was causing some ELBs to leak.

---

I confirmed that apps, databases, replicas, and endpoints are now all deprovisioned and not just deleted.