### PR TITLE
Return DB Image information in GetDatabase

### DIFF
--- a/aptible/database.go
+++ b/aptible/database.go
@@ -156,6 +156,19 @@ func (c *Client) GetDatabase(databaseID int64) (Database, error) {
 		database.Service = service
 	}
 
+	if resp.Payload.Links.DatabaseImage != nil {
+		imageHref := resp.Payload.Links.DatabaseImage.Href.String()
+		imageID, err := GetIDFromHref(imageHref)
+		if err != nil {
+			return database, err
+		}
+		dbImage, err := c.GetDatabaseImage(imageID)
+		if err != nil {
+			return database, err
+		}
+		database.DatabaseImage = dbImage
+	}
+
 	return database, nil
 }
 

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -158,11 +158,7 @@ func (c *Client) GetDatabase(databaseID int64) (Database, error) {
 
 	if resp.Payload.Links.DatabaseImage != nil {
 		imageHref := resp.Payload.Links.DatabaseImage.Href.String()
-		imageID, err := GetIDFromHref(imageHref)
-		if err != nil {
-			return database, err
-		}
-		dbImage, err := c.GetDatabaseImage(imageID)
+		dbImage, err := c.GetImageFromHref(imageHref)
 		if err != nil {
 			return database, err
 		}


### PR DESCRIPTION
This sets the DatabaseImage in the GetDatabase client call. We need to
return that information so that we can accurately set the version in the
terraform provider.