### PR TITLE
:sparkles: add log drain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bin/
 swagger.yaml
 swagger.json
 swagger.yml
+
+.envrc

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -3,9 +3,9 @@ package aptible
 import (
 	"fmt"
 
-	strfmt "github.com/go-openapi/strfmt"
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
+	strfmt "github.com/go-openapi/strfmt"
 )
 
 type LogDrain struct {

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 type LogDrain struct {
@@ -64,19 +65,26 @@ func (c *Client) CreateLogDrain(handle string, accountID int64, attrs *LogDrainC
 		return logDrain, fmt.Errorf("log drain ID is a nil pointer")
 	}
 	logDrain.ID = *response.Payload.ID
-	logDrain.Handle = *response.Payload.Handle
-	logDrain.DrainType = *response.Payload.DrainType
-	logDrain.DrainHost = *response.Payload.DrainHost
-	logDrain.DrainPort = *response.Payload.DrainPort
-	logDrain.LoggingToken = *response.Payload.LoggingToken
-	logDrain.URL = *response.Payload.URL
-	logDrain.DrainApps = *response.Payload.DrainApps
-	logDrain.DrainDatabases = *response.Payload.DrainDatabases
-	logDrain.DrainEphemeralSessions = *response.Payload.DrainEphemeralSessions
-	logDrain.DrainProxies = *response.Payload.DrainProxies
-	logDrain.Deleted = false
 
-	return logDrain, nil
+	requestType := "provision"
+	operationRequest := &models.AppRequest29{Type: &requestType}
+	operationParams := operations.NewPostLogDrainsLogDrainIDOperationsParams().WithLogDrainID(logDrain.ID).WithAppRequest(operationRequest)
+	operationResponse, err := c.Client.Operations.PostLogDrainsLogDrainIDOperations(operationParams, c.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait on provision operation to complete.
+	if operationResponse.Payload.ID == nil {
+		return nil, fmt.Errorf("operation ID is a nil pointer")
+	}
+	operationID := *operationResponse.Payload.ID
+	_, err = c.WaitForOperation(operationID)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetLogDrain(logDrain.ID)
 }
 
 func (c *Client) GetLogDrain(logDrainID int64) (*LogDrain, error) {
@@ -90,7 +98,7 @@ func (c *Client) GetLogDrain(logDrainID int64) (*LogDrain, error) {
 		errStruct := err.(*operations.GetLogDrainsIDDefault)
 		switch errStruct.Code() {
 		case 404:
-			// If deleted == true, then the endpoint needs to be removed from Terraform.
+			// If deleted == true, then the log_drain needs to be removed from Terraform.
 			logDrain.Deleted = true
 			return logDrain, nil
 		case 401:
@@ -102,34 +110,30 @@ func (c *Client) GetLogDrain(logDrainID int64) (*LogDrain, error) {
 		}
 	}
 
-	if response.Payload.ID == nil {
-		return logDrain, fmt.Errorf("payload.ID is a nil pointer")
-	}
-	logDrain.ID = *response.Payload.ID
-	logDrain.DrainType = *response.Payload.DrainType
-	logDrain.Handle = *response.Payload.Handle
-	logDrain.DrainType = *response.Payload.DrainType
-	logDrain.DrainHost = *response.Payload.DrainHost
-	logDrain.DrainPort = *response.Payload.DrainPort
-	logDrain.LoggingToken = *response.Payload.LoggingToken
-	logDrain.URL = *response.Payload.URL
-	logDrain.DrainApps = *response.Payload.DrainApps
-	logDrain.DrainDatabases = *response.Payload.DrainDatabases
-	logDrain.DrainEphemeralSessions = *response.Payload.DrainEphemeralSessions
-	logDrain.DrainProxies = *response.Payload.DrainProxies
+	logDrain.ID = swag.Int64Value(response.Payload.ID)
+	logDrain.DrainType = swag.StringValue(response.Payload.DrainType)
+	logDrain.Handle = swag.StringValue(response.Payload.Handle)
+	logDrain.DrainType = swag.StringValue(response.Payload.DrainType)
+	logDrain.DrainHost = swag.StringValue(response.Payload.DrainHost)
+	logDrain.DrainPort = swag.Int64Value(response.Payload.DrainPort)
+	logDrain.LoggingToken = swag.StringValue(response.Payload.LoggingToken)
+	logDrain.URL = swag.StringValue(response.Payload.URL)
+	logDrain.DrainApps = swag.BoolValue(response.Payload.DrainApps)
+	logDrain.DrainDatabases = swag.BoolValue(response.Payload.DrainDatabases)
+	logDrain.DrainEphemeralSessions = swag.BoolValue(response.Payload.DrainEphemeralSessions)
+	logDrain.DrainProxies = swag.BoolValue(response.Payload.DrainProxies)
 	return logDrain, nil
 }
 
-func (c *Client) DeleteLogDrain(logDrainID int64) error {
+func (c *Client) DeleteLogDrain(logDrainID int64) (bool, error) {
 	requestType := "deprovision"
 	request := models.AppRequest29{Type: &requestType}
 	params := operations.NewPostLogDrainsLogDrainIDOperationsParams().WithLogDrainID(logDrainID).WithAppRequest(&request)
 	op, err := c.Client.Operations.PostLogDrainsLogDrainIDOperations(params, c.Token)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	operationID := *op.Payload.ID
-	_, err = c.WaitForOperation(operationID)
-	return err
+	return c.WaitForOperation(operationID)
 }

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -2,8 +2,8 @@ package aptible
 
 import (
 	"fmt"
-	strfmt "github.com/go-openapi/strfmt"
 
+	strfmt "github.com/go-openapi/strfmt"
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -9,10 +9,18 @@ import (
 )
 
 type LogDrain struct {
-	Deleted   bool
-	ID        int64
-	Handle    string
-	DrainType string
+	Deleted                bool
+	ID                     int64
+	Handle                 string
+	DrainType              string
+	DrainApps              bool
+	DrainDatabases         bool
+	DrainEphemeralSessions bool
+	DrainProxies           bool
+	DrainHost              string
+	DrainPort              int64
+	LoggingToken           string
+	URL                    string
 }
 
 type LogDrainCreateAttrs struct {
@@ -21,12 +29,11 @@ type LogDrainCreateAttrs struct {
 	DrainApps              bool
 	DrainDatabases         bool
 	DrainEphemeralSessions bool
+	DrainProxies           bool
 	DrainHost              strfmt.URI
 	DrainPassword          string
 	DrainPort              int64
-	DrainProxies           bool
 	DrainType              *string
-	Handle                 *string
 	LoggingToken           string
 	URL                    strfmt.URI
 }
@@ -59,6 +66,14 @@ func (c *Client) CreateLogDrain(handle string, accountID int64, attrs *LogDrainC
 	logDrain.ID = *response.Payload.ID
 	logDrain.Handle = *response.Payload.Handle
 	logDrain.DrainType = *response.Payload.DrainType
+	logDrain.DrainHost = *response.Payload.DrainHost
+	logDrain.DrainPort = *response.Payload.DrainPort
+	logDrain.LoggingToken = *response.Payload.LoggingToken
+	logDrain.URL = *response.Payload.URL
+	logDrain.DrainApps = *response.Payload.DrainApps
+	logDrain.DrainDatabases = *response.Payload.DrainDatabases
+	logDrain.DrainEphemeralSessions = *response.Payload.DrainEphemeralSessions
+	logDrain.DrainProxies = *response.Payload.DrainProxies
 	logDrain.Deleted = false
 
 	return logDrain, nil
@@ -93,6 +108,15 @@ func (c *Client) GetLogDrain(logDrainID int64) (*LogDrain, error) {
 	logDrain.ID = *response.Payload.ID
 	logDrain.DrainType = *response.Payload.DrainType
 	logDrain.Handle = *response.Payload.Handle
+	logDrain.DrainType = *response.Payload.DrainType
+	logDrain.DrainHost = *response.Payload.DrainHost
+	logDrain.DrainPort = *response.Payload.DrainPort
+	logDrain.LoggingToken = *response.Payload.LoggingToken
+	logDrain.URL = *response.Payload.URL
+	logDrain.DrainApps = *response.Payload.DrainApps
+	logDrain.DrainDatabases = *response.Payload.DrainDatabases
+	logDrain.DrainEphemeralSessions = *response.Payload.DrainEphemeralSessions
+	logDrain.DrainProxies = *response.Payload.DrainProxies
 	return logDrain, nil
 }
 

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -1,0 +1,111 @@
+package aptible
+
+import (
+	"fmt"
+	strfmt "github.com/go-openapi/strfmt"
+
+	"github.com/aptible/go-deploy/client/operations"
+	"github.com/aptible/go-deploy/models"
+)
+
+type LogDrain struct {
+	Deleted   bool
+	ID        int64
+	Handle    string
+	DrainType string
+}
+
+type LogDrainCreateAttrs struct {
+	Database               strfmt.URI
+	DatabaseID             int64
+	DrainApps              bool
+	DrainDatabases         bool
+	DrainEphemeralSessions bool
+	DrainHost              strfmt.URI
+	DrainPassword          string
+	DrainPort              int64
+	DrainProxies           bool
+	DrainType              *string
+	Handle                 *string
+	LoggingToken           string
+	URL                    strfmt.URI
+}
+
+func (c *Client) CreateLogDrain(handle *string, accountID int64, attrs *LogDrainCreateAttrs) (*LogDrain, error) {
+	request := &models.AppRequest16{
+		Database:               attrs.Database,
+		DatabaseID:             attrs.DatabaseID,
+		DrainApps:              attrs.DrainApps,
+		DrainDatabases:         attrs.DrainDatabases,
+		DrainEphemeralSessions: attrs.DrainEphemeralSessions,
+		DrainHost:              attrs.DrainHost,
+		DrainPassword:          attrs.DrainPassword,
+		DrainPort:              attrs.DrainPort,
+		DrainType:              attrs.DrainType,
+		Handle:                 handle,
+		LoggingToken:           attrs.LoggingToken,
+		URL:                    attrs.URL,
+	}
+	logDrain := &LogDrain{}
+	params := operations.NewPostAccountsAccountIDLogDrainsParams().WithAccountID(accountID).WithAppRequest(request)
+	response, err := c.Client.Operations.PostAccountsAccountIDLogDrains(params, c.Token)
+	if err != nil {
+		return logDrain, err
+	}
+
+	if response.Payload.ID == nil {
+		return logDrain, fmt.Errorf("log drain ID is a nil pointer")
+	}
+	logDrain.ID = *response.Payload.ID
+	logDrain.Handle = *response.Payload.Handle
+	logDrain.DrainType = *response.Payload.DrainType
+	logDrain.Deleted = false
+
+	return logDrain, nil
+}
+
+func (c *Client) GetLogDrain(logDrainID int64) (*LogDrain, error) {
+	logDrain := &LogDrain{
+		Deleted: false,
+	}
+
+	params := operations.NewGetLogDrainsIDParams().WithID(logDrainID)
+	response, err := c.Client.Operations.GetLogDrainsID(params, c.Token)
+	if err != nil {
+		errStruct := err.(*operations.GetLogDrainsIDDefault)
+		switch errStruct.Code() {
+		case 404:
+			// If deleted == true, then the endpoint needs to be removed from Terraform.
+			logDrain.Deleted = true
+			return logDrain, nil
+		case 401:
+			e := fmt.Errorf("make sure you have the correct auth token")
+			return logDrain, e
+		default:
+			e := fmt.Errorf("there was an error when completing the request to get the app \n[ERROR] -%s", err)
+			return logDrain, e
+		}
+	}
+
+	if response.Payload.ID == nil {
+		return logDrain, fmt.Errorf("payload.ID is a nil pointer")
+	}
+	logDrain.ID = *response.Payload.ID
+	logDrain.DrainType = *response.Payload.DrainType
+	logDrain.Handle = *response.Payload.Handle
+	return logDrain, nil
+}
+
+func (c *Client) DeleteLogDrain(logDrainID int64) error {
+	requestType := "deprovision"
+	request := models.AppRequest29{Type: &requestType}
+	params := operations.NewPostLogDrainsLogDrainIDOperationsParams().WithLogDrainID(logDrainID).WithAppRequest(&request)
+	op, err := c.Client.Operations.PostLogDrainsLogDrainIDOperations(params, c.Token)
+	if err != nil {
+		return err
+	}
+
+	operationID := *op.Payload.ID
+	_, err = c.WaitForOperation(operationID)
+	return err
+}

--- a/aptible/log_drain.go
+++ b/aptible/log_drain.go
@@ -31,7 +31,7 @@ type LogDrainCreateAttrs struct {
 	URL                    strfmt.URI
 }
 
-func (c *Client) CreateLogDrain(handle *string, accountID int64, attrs *LogDrainCreateAttrs) (*LogDrain, error) {
+func (c *Client) CreateLogDrain(handle string, accountID int64, attrs *LogDrainCreateAttrs) (*LogDrain, error) {
 	request := &models.AppRequest16{
 		Database:               attrs.Database,
 		DatabaseID:             attrs.DatabaseID,
@@ -42,7 +42,7 @@ func (c *Client) CreateLogDrain(handle *string, accountID int64, attrs *LogDrain
 		DrainPassword:          attrs.DrainPassword,
 		DrainPort:              attrs.DrainPort,
 		DrainType:              attrs.DrainType,
-		Handle:                 handle,
+		Handle:                 &handle,
 		LoggingToken:           attrs.LoggingToken,
 		URL:                    attrs.URL,
 	}


### PR DESCRIPTION
https://aptible.atlassian.net/browse/DP-554

```go
// CREATE
drainType := "elasticsearch_database"
logDrain, err := c.CreateLogDrain("es-logs", 2, &aptible.LogDrainCreateAttrs{
    DrainType: &drainType,
    DatabaseID: 2,
    DrainApps: true,
    DrainDatabases: true,
    DrainEphemeralSessions: true,
    DrainProxies: false,
})
if err != nil {
    apiErr := err.(*operations.PostAccountsAccountIDLogDrainsDefault)
    log.Fatalf("%s: %s\n", err, *apiErr.Payload.Message)
}

// GET
getLogDrain, err := c.GetLogDrain(logDrain.ID)
if err != nil {
    apiErr := err.(*operations.PostAccountsAccountIDLogDrainsDefault)
    log.Fatalf("%s: %s\n", err, *apiErr.Payload.Message)
}
fmt.Println(getLogDrain)

// DELETE
err = c.DeleteLogDrain(logDrain.ID)
if (err != nil) {
    apiErr := err.(*operations.PostLogDrainsLogDrainIDOperationsDefault)
    log.Fatalf("%s: %s\n", err, *apiErr.Payload.Message)
}
```