### PR TITLE
Allow directly supplying token to client to support megatime

### DIFF
--- a/aptible/api_required_test.go
+++ b/aptible/api_required_test.go
@@ -1,3 +1,4 @@
+//go:build api
 // +build api
 
 // These tests call SetUpClient and require a valid client

--- a/aptible/app.go
+++ b/aptible/app.go
@@ -128,6 +128,19 @@ func (c *Client) DeployApp(config map[string]interface{}, appID int64) error {
 	return err
 }
 
+func (c *Client) DeployGitApp(appID int64, commitish string) (int64, error) {
+	requestType := "deploy"
+	appRequest := models.AppRequest22{Type: &requestType, GitRef: commitish}
+	appParams := operations.NewPostAppsAppIDOperationsParams().WithAppID(appID).WithAppRequest(&appRequest)
+	response, err := c.Client.Operations.PostAppsAppIDOperations(appParams, c.Token)
+	if err != nil {
+		return 0, err
+	}
+
+	operationID := *response.Payload.ID
+	return operationID, nil
+}
+
 func (c *Client) DeleteApp(appID int64) (bool, error) {
 	requestType := "deprovision"
 	appRequest := models.AppRequest22{Type: &requestType}

--- a/aptible/client.go
+++ b/aptible/client.go
@@ -19,6 +19,15 @@ type Client struct {
 
 // sets up client and gets auth token used for API requests
 func SetUpClient() (*Client, error) {
+	token, err := GetToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(token)
+}
+
+func NewClient(token string) (*Client, error) {
 	host, err := GetHost()
 	if err != nil {
 		return nil, err
@@ -32,10 +41,6 @@ func SetUpClient() (*Client, error) {
 	rt.Producers["application/hal+json"] = runtime.JSONProducer()
 	client := deploy.New(rt, strfmt.Default)
 
-	token, err := GetToken()
-	if err != nil {
-		return nil, err
-	}
 	bearerTokenAuth := httptransport.BearerToken(token)
 
 	c := Client{}


### PR DESCRIPTION
In megatime, we will have clients pass us their existing token, which
megatime will then use to make API calls on their behalf. To support
this, we allow for the creation of a Client passed on a passed in token
versus a lookup from the environment.