### PR TITLE
feat: added handles from changes in update funcs from deploy-api spec change

### DIFF
--- a/aptible/app.go
+++ b/aptible/app.go
@@ -17,6 +17,11 @@ type App struct {
 	Services      []Service
 }
 
+type AppUpdates struct {
+	// Handle - field to update app handle
+	Handle string
+}
+
 func (c *Client) CreateApp(handle string, accountID int64) (App, error) {
 	app := App{}
 	appRequest := models.AppRequest3{Handle: &handle}
@@ -124,6 +129,17 @@ func (c *Client) DeployApp(config map[string]interface{}, appID int64) error {
 
 	operationID := *response.Payload.ID
 	_, err = c.WaitForOperation(operationID)
+
+	return err
+}
+
+func (c *Client) UpdateApp(appID int64, appUpdates AppUpdates) error {
+	patchRequest := models.PatchRequest{
+		Handle: appUpdates.Handle,
+	}
+
+	updateAppParams := operations.NewPutAppsIDParams().WithID(appID).WithPatchRequest(&patchRequest)
+	_, err := c.Client.Operations.PutAppsID(updateAppParams, c.Token)
 
 	return err
 }

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -185,18 +185,6 @@ func (c *Client) GetDatabase(databaseID int64) (Database, error) {
 }
 
 func (c *Client) UpdateDatabase(databaseID int64, updates DBUpdates) error {
-	if updates.Handle != "" {
-		// need to update the database directly
-		databaseUpdateRequest := models.AppRequest14{
-			Handle: updates.Handle,
-		}
-		updateDatabaseParams := operations.NewPutDatabasesIDParams().WithID(databaseID).WithAppRequest(&databaseUpdateRequest)
-		_, err := c.Client.Operations.PutDatabasesID(updateDatabaseParams, c.Token)
-		if err != nil {
-			return err
-		}
-	}
-
 	requestType := "restart"
 	request := models.AppRequest24{
 		Type: &requestType,
@@ -225,6 +213,18 @@ func (c *Client) UpdateDatabase(databaseID int64, updates DBUpdates) error {
 			return fmt.Errorf("id is a nil pointer")
 		}
 
+	}
+
+	if updates.Handle != "" {
+		// need to update the database directly
+		databaseUpdateRequest := models.AppRequest14{
+			Handle: updates.Handle,
+		}
+		updateDatabaseParams := operations.NewPutDatabasesIDParams().WithID(databaseID).WithAppRequest(&databaseUpdateRequest)
+		_, err := c.Client.Operations.PutDatabasesID(updateDatabaseParams, c.Token)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -23,9 +23,15 @@ type Database struct {
 	DatabaseImage     DatabaseImage
 }
 
+// DBUpdates - struct to define what operations you contain your DB update to. Add values to this struct
+// 			   to eventually pass it around for consumption by the go sdk
 type DBUpdates struct {
 	ContainerSize int64
 	DiskSize      int64
+	Handle        string
+	// OnlyChangingHandle - changing a DB can incur multiple API calls. To contain it to only update the handle
+	// 						set this to true so you only make one API call (to update database itself)
+	OnlyChangingHandle bool
 }
 
 type DBCreateAttrs struct {
@@ -179,6 +185,18 @@ func (c *Client) GetDatabase(databaseID int64) (Database, error) {
 }
 
 func (c *Client) UpdateDatabase(databaseID int64, updates DBUpdates) error {
+	if updates.Handle != "" {
+		// need to update the database directly
+		databaseUpdateRequest := models.AppRequest14{
+			Handle: updates.Handle,
+		}
+		updateDatabaseParams := operations.NewPutDatabasesIDParams().WithID(databaseID).WithAppRequest(&databaseUpdateRequest)
+		_, err := c.Client.Operations.PutDatabasesID(updateDatabaseParams, c.Token)
+		if err != nil {
+			return err
+		}
+	}
+
 	requestType := "restart"
 	request := models.AppRequest24{
 		Type: &requestType,
@@ -191,19 +209,22 @@ func (c *Client) UpdateDatabase(databaseID int64, updates DBUpdates) error {
 		request.DiskSize = updates.DiskSize
 	}
 
-	params := operations.NewPostDatabasesDatabaseIDOperationsParams().WithDatabaseID(databaseID).WithAppRequest(&request)
-	op, err := c.Client.Operations.PostDatabasesDatabaseIDOperations(params, c.Token)
-	if err != nil {
-		return err
-	}
-	if op.Payload.ID != nil {
-		operationID := *op.Payload.ID
-		_, err = c.WaitForOperation(operationID)
+	if !updates.OnlyChangingHandle {
+		params := operations.NewPostDatabasesDatabaseIDOperationsParams().WithDatabaseID(databaseID).WithAppRequest(&request)
+		op, err := c.Client.Operations.PostDatabasesDatabaseIDOperations(params, c.Token)
 		if err != nil {
 			return err
 		}
-	} else {
-		return fmt.Errorf("id is a nil pointer")
+		if op.Payload.ID != nil {
+			operationID := *op.Payload.ID
+			_, err = c.WaitForOperation(operationID)
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("id is a nil pointer")
+		}
+
 	}
 
 	return nil

--- a/models/app_request14.go
+++ b/models/app_request14.go
@@ -24,6 +24,9 @@ type AppRequest14 struct {
 	// database image id
 	DatabaseImageID int64 `json:"database_image_id,omitempty"`
 
+	// handle
+	Handle string `json:"handle,omitempty"`
+
 	// initial continer size
 	InitialContinerSize int64 `json:"initial_continer_size,omitempty"`
 

--- a/models/app_request15.go
+++ b/models/app_request15.go
@@ -24,6 +24,9 @@ type AppRequest15 struct {
 	// database image id
 	DatabaseImageID int64 `json:"database_image_id,omitempty"`
 
+	// handle
+	Handle string `json:"handle,omitempty"`
+
 	// initial continer size
 	InitialContinerSize int64 `json:"initial_continer_size,omitempty"`
 

--- a/models/patch_request.go
+++ b/models/patch_request.go
@@ -25,6 +25,9 @@ type PatchRequest struct {
 	// Format: uri
 	CurrentImage strfmt.URI `json:"current_image,omitempty"`
 
+	// handle
+	Handle string `json:"handle,omitempty"`
+
 	// status
 	Status string `json:"status,omitempty"`
 }

--- a/models/patch_request1.go
+++ b/models/patch_request1.go
@@ -25,6 +25,9 @@ type PatchRequest1 struct {
 	// Format: uri
 	CurrentImage strfmt.URI `json:"current_image,omitempty"`
 
+	// handle
+	Handle string `json:"handle,omitempty"`
+
 	// status
 	Status string `json:"status,omitempty"`
 }


### PR DESCRIPTION
This should allow for updating handles of:

* apps
* dbs

---

The below four model changes were generated in the existing generator (@almathew ). This has not changed.