### PR TITLE
Include endpoint type when invalid

### DIFF
--- a/aptible/endpoints.go
+++ b/aptible/endpoints.go
@@ -285,7 +285,7 @@ func GetHumanReadableEndpointType(t string) (string, error) {
 	case "tls":
 		return "tls", nil
 	default:
-		e := fmt.Errorf("invalid endpoint type")
+		e := fmt.Errorf("invalid endpoint type - %s", t)
 		return "", e
 	}
 }


### PR DESCRIPTION
## Context
I am working on debugging an error when importing an HTTP endpoint into terraform and getting the error `error: invalid endpoint type` which is unhelpful as it should be a supported type (`http_proxy_protocol` - `https`) and I'm unsure what the client is getting.

## Description
This PR adds the endpoint type to the error when the provided endpoint does not match a type in the case

## Overview
- add endpoint type to error message when type provided does not match human readable case