### PR TITLE
feat: added stack id and org id to returns on env get

### DIFF
--- a/aptible/environment.go
+++ b/aptible/environment.go
@@ -77,7 +77,7 @@ func (c *Client) GetEnvironment(environmentID int64) (Environment, error) {
 	}
 	organizationSplitLink := strings.Split(environmentData.Payload.Links.Organization.Href.String(), "/")
 	if len(organizationSplitLink) == 0 {
-		e := fmt.Errorf("there was an error when completing the request to get the organization id from the environment, href invalid - %s", organizationSplitLink)
+		e := fmt.Errorf("there was an error when completing the request to get the organization id from the environment, href invalid - %s", environmentData.Payload.Links.Organization.Href.String())
 		return Environment{}, e
 	}
 	organizationID := organizationSplitLink[len(organizationSplitLink)-1]

--- a/aptible/environment.go
+++ b/aptible/environment.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
@@ -9,9 +10,11 @@ import (
 )
 
 type Environment struct {
-	Deleted bool
-	Handle  string
-	ID      int64
+	Deleted        bool
+	Handle         string
+	ID             int64
+	StackID        int64
+	OrganizationID string
 }
 
 type EnvironmentUpdates struct {
@@ -42,8 +45,10 @@ func (c *Client) CreateEnvironment(organizationID string, stackID int64, attrs E
 		return Environment{}, err
 	}
 	return Environment{
-		Handle: *environment.Payload.Handle,
-		ID:     *environment.Payload.ID,
+		Handle:         *environment.Payload.Handle,
+		ID:             *environment.Payload.ID,
+		StackID:        stackID,
+		OrganizationID: organizationID,
 	}, nil
 }
 
@@ -66,8 +71,21 @@ func (c *Client) GetEnvironment(environmentID int64) (Environment, error) {
 			return Environment{}, e
 		}
 	}
+	stackID, err := GetIDFromHref(environmentData.Payload.Links.Stack.Href.String())
+	if err != nil {
+		return Environment{}, err
+	}
+	organizationSplitLink := strings.Split(environmentData.Payload.Links.Organization.Href.String(), "/")
+	if len(organizationSplitLink) == 0 {
+		e := fmt.Errorf("there was an error when completing the request to get the organization id from the environment \n[ERROR] -%s", err)
+		return Environment{}, e
+	}
+	organizationID := organizationSplitLink[len(organizationSplitLink)-1]
+
 	environment.Handle = swag.StringValue(environmentData.Payload.Handle)
 	environment.ID = swag.Int64Value(environmentData.Payload.ID)
+	environment.StackID = stackID
+	environment.OrganizationID = organizationID
 	return environment, nil
 }
 

--- a/aptible/environment.go
+++ b/aptible/environment.go
@@ -77,7 +77,7 @@ func (c *Client) GetEnvironment(environmentID int64) (Environment, error) {
 	}
 	organizationSplitLink := strings.Split(environmentData.Payload.Links.Organization.Href.String(), "/")
 	if len(organizationSplitLink) == 0 {
-		e := fmt.Errorf("there was an error when completing the request to get the organization id from the environment \n[ERROR] -%s", err)
+		e := fmt.Errorf("there was an error when completing the request to get the organization id from the environment, href invalid - %s", organizationSplitLink)
 		return Environment{}, e
 	}
 	organizationID := organizationSplitLink[len(organizationSplitLink)-1]

--- a/test/integration/environment_test.go
+++ b/test/integration/environment_test.go
@@ -52,6 +52,14 @@ func TestEnvironments(t *testing.T) {
 		t.Errorf("Expected the environment to be the same as when it was created: expected %v, got %v", prevEnvironment, environment)
 		return
 	}
+	if !reflect.DeepEqual(environment.OrganizationID, orgID) {
+		t.Errorf("Expected the organization id to be the same as when it was created: expected %v, got %v", environment.OrganizationID, orgID)
+		return
+	}
+	if !reflect.DeepEqual(environment.StackID, stackID) {
+		t.Errorf("Expected the stack id to be the same as when it was created: expected %v, got %v", environment.StackID, stackID)
+		return
+	}
 
 	// update it
 	fmt.Println("Testing environment update")


### PR DESCRIPTION
N/A

This should correctly return the stack id and org id (somewhat of an identity) from the environment create.

Proof of function:

<img width="553" alt="image" src="https://user-images.githubusercontent.com/2961973/196466210-13f71d94-d32d-46ef-934f-52322dd75945.png">
