### PR TITLE
fix: added environment and stack look ups by handle with proper pagination

### DIFF
--- a/aptible/stack.go
+++ b/aptible/stack.go
@@ -79,7 +79,6 @@ func (c *Client) GetStackByName(name string) (Stack, error) {
 	if err != nil {
 		return Stack{}, err
 	}
-	var stacksToReturn Stack
 	for _, stack := range stacks {
 		if name == stack.Name {
 			return Stack{
@@ -89,5 +88,5 @@ func (c *Client) GetStackByName(name string) (Stack, error) {
 			}, nil
 		}
 	}
-	return stacksToReturn, fmt.Errorf("Error, unable to find stack from the name provided: %s\n", name)
+	return Stack{}, fmt.Errorf("Error, unable to find stack from the name provided: %s\n", name)
 }

--- a/aptible/stack.go
+++ b/aptible/stack.go
@@ -80,11 +80,7 @@ func (c *Client) GetStackByName(name string) (Stack, error) {
 	}
 	for _, stack := range stacks {
 		if name == stack.Name {
-			return Stack{
-				ID:             stack.ID,
-				Name:           stack.Name,
-				OrganizationID: stack.OrganizationID,
-			}, nil
+			return stack, nil
 		}
 	}
 	return Stack{}, fmt.Errorf("Error, unable to find stack from the name provided: %s\n", name)

--- a/aptible/stack.go
+++ b/aptible/stack.go
@@ -66,12 +66,11 @@ func (c *Client) GetStack(id int64) (Stack, error) {
 		orgIdParts := strings.Split(result.Payload.Links.Organization.Href.String(), "/")
 		organizationId = orgIdParts[len(orgIdParts)-1]
 	}
-	stackToReturn := Stack{
+	return Stack{
 		ID:             id,
 		OrganizationID: organizationId,
 		Name:           *result.Payload.Name,
-	}
-	return stackToReturn, nil
+	}, nil
 }
 
 func (c *Client) GetStackByName(name string) (Stack, error) {

--- a/aptible/stack.go
+++ b/aptible/stack.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aptible/go-deploy/client/operations"
 )
 
+const MaximumPagesOfStacks = 10
+
 type Stack struct {
 	ID             int64
 	OrganizationID string
@@ -17,26 +19,36 @@ func (s Stack) isShared() bool {
 	return s.OrganizationID == ""
 }
 
-func (c *Client) UNSUPPORTED_GetStacks() ([]Stack, error) {
-	page := int64(0)
-	params := operations.NewGetStacksParams().WithPage(&page)
+func (c *Client) GetStacks() ([]Stack, error) {
+	page := int64(1)
+	stacksToReturn := make([]Stack, 0)
 
-	stacks, err := c.Client.Operations.GetStacks(params, c.Token)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		params := operations.NewGetStacksParams().WithPage(&page)
+		stacks, err := c.Client.Operations.GetStacks(params, c.Token)
+		if err != nil {
+			return nil, err
+		} else if len(stacks.GetPayload().Embedded.Stacks) == 0 {
+			break
+		} else if page >= MaximumPagesOfStacks {
+			// infinite loop guard
+			return nil, fmt.Errorf("exceeded %d pages of results for stacks in population. "+
+				"Something has gone wrong", MaximumPagesOfStacks)
+		}
 
-	stacksToReturn := make([]Stack, len(stacks.Payload.Embedded.Stacks))
-	for idx := range stacksToReturn {
-		stacksToReturn[idx] = Stack{
-			ID:   stacks.Payload.Embedded.Stacks[idx].ID,
-			Name: stacks.Payload.Embedded.Stacks[idx].Name,
+		for _, stack := range stacks.GetPayload().Embedded.Stacks {
+			stackToAppend := Stack{
+				ID:   stack.ID,
+				Name: stack.Name,
+			}
+			if stack.Links.Organization != nil &&
+				stack.Links.Organization.Href != "" {
+				orgIdParts := strings.Split(stack.Links.Organization.Href.String(), "/")
+				stackToAppend.OrganizationID = orgIdParts[len(orgIdParts)-1]
+			}
+			stacksToReturn = append(stacksToReturn, stackToAppend)
 		}
-		if stacks.Payload.Embedded.Stacks[idx].Links.Organization != nil &&
-			stacks.Payload.Embedded.Stacks[idx].Links.Organization.Href != "" {
-			orgIdParts := strings.Split(stacks.Payload.Embedded.Stacks[idx].Links.Organization.Href.String(), "/")
-			stacksToReturn[idx].OrganizationID = orgIdParts[len(orgIdParts)-1]
-		}
+		page += 1
 	}
 
 	return stacksToReturn, nil
@@ -62,8 +74,8 @@ func (c *Client) GetStack(id int64) (Stack, error) {
 	return stackToReturn, nil
 }
 
-func (c *Client) UNSUPPORTED_GetStackByName(name string) (Stack, error) {
-	stacks, err := c.UNSUPPORTED_GetStacks()
+func (c *Client) GetStackByName(name string) (Stack, error) {
+	stacks, err := c.GetStacks()
 	if err != nil {
 		return Stack{}, err
 	}

--- a/test/integration/environment_test.go
+++ b/test/integration/environment_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -26,8 +27,13 @@ func TestEnvironments(t *testing.T) {
 			t.Error("Expected GetEnvironment to not return an error but got", err.Error())
 		}
 	}
-
 	testNotFound(0)
+
+	_, err = client.GetEnvironmentFromHandle(fmt.Sprintf("THIS_HANDLE_SHOULD_NOT_EXIST_%d", rand.Int()))
+	if err == nil {
+		t.Error("Expected no environment to be found and magically one was found!", err.Error())
+		return
+	}
 
 	// create it
 	fmt.Println("Testing environment creation")
@@ -36,6 +42,16 @@ func TestEnvironments(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal("Expected CreateEnvironment to not return an error but got", err.Error())
+		return
+	}
+
+	environmentByHandle, err := client.GetEnvironmentFromHandle(environment.Handle)
+	if err != nil {
+		t.Fatal("Expected GetEnvironmentFromHandle to find an environment with handle provided, but it errored", err.Error())
+		return
+	}
+	if environmentByHandle.Handle != environment.Handle {
+		t.Fatal("Expected found environment handle (environmentByHandle) to match the one that was provided yet (environment) there is a mismatch", environmentByHandle.Handle, environment.Handle)
 		return
 	}
 

--- a/test/integration/stack_test.go
+++ b/test/integration/stack_test.go
@@ -21,7 +21,7 @@ func TestStack(t *testing.T) {
 	}
 
 	fmt.Println("Testing non-existent stack get by name (should err)")
-	individualResult, err := client.UNSUPPORTED_GetStackByName("THIS_STACK_SHOULD_NOT_EXIST_EVER")
+	individualResult, err := client.GetStackByName("THIS_STACK_SHOULD_NOT_EXIST_EVER")
 	if err == nil {
 		t.Fatal("Expected GetStackByName to return an error but did not get an err!")
 		return
@@ -32,13 +32,24 @@ func TestStack(t *testing.T) {
 	}
 
 	fmt.Println("Testing get stack list")
-	results, err := client.UNSUPPORTED_GetStacks()
+	results, err := client.GetStacks()
 	if err != nil {
 		t.Fatal("Expected GetStacks to not return an error but got", err.Error())
 		return
 	}
 	if len(results) == 0 {
 		t.Fatal("Expected results from stacks in payload ")
+		return
+	}
+
+	fmt.Println("Testing get stack by name")
+	stackResultByName, err := client.GetStackByName(results[0].Name)
+	if err != nil {
+		t.Fatal("Expected GetStackByName to function properly without an error but got", err.Error())
+		return
+	}
+	if stackResultByName.Name != results[0].Name {
+		t.Fatal("Expected stack name to match the one that was requested to be created but got a mismatch", stackResultByName.Name, results[0].Name)
 		return
 	}
 
@@ -51,7 +62,7 @@ func TestStack(t *testing.T) {
 	}
 
 	fmt.Println("Testing get by stack by name")
-	resultByName, err := client.UNSUPPORTED_GetStackByName(results[0].Name)
+	resultByName, err := client.GetStackByName(results[0].Name)
 	if err != nil {
 		t.Fatal("Expected GetStackByName to not return an error but got", err.Error())
 		return


### PR DESCRIPTION
This is hugely contingent on a few behaviors:

1. The pagination looks to return empty arrays if gone beyond the present page (ex: page 0 -1 - 2 - 3, say no results on page2/3, it will return an empty array)
2. I set arbitrary maximum page limits for the while loops, we can make this more elegant if needed

The tests worked (and i had multiple pages worth of environments) on my test stack:

<img width="830" alt="image" src="https://user-images.githubusercontent.com/2961973/196823497-ea809890-b223-45f8-9325-54a8e18c639a.png">

<img width="976" alt="image" src="https://user-images.githubusercontent.com/2961973/196823525-8c6d089a-6215-4bcf-aa21-ccc9c836cdcd.png">
