### PR TITLE
feat: added ability to pull organization id from a provided token

### DIFF
--- a/aptible/client.go
+++ b/aptible/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 type Client struct {
-	Client *deploy.DeployAPIV1
-	Token  runtime.ClientAuthInfoWriter
+	Client   *deploy.DeployAPIV1
+	Token    runtime.ClientAuthInfoWriter
+	RawToken string
 }
 
 // sets up client and gets auth token used for API requests
@@ -36,11 +37,13 @@ func SetUpClient() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	bearerTokenAuth := httptransport.BearerToken(token)
 
 	c := Client{}
 	c.Client = client
 	c.Token = bearerTokenAuth
+	c.RawToken = token
 	return &c, nil
 }
 

--- a/aptible/organizations.go
+++ b/aptible/organizations.go
@@ -35,7 +35,10 @@ func (c *Client) getOrganizations() ([]Organization, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	} else if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("did not receive 200 from auth, check credentials - %d status code received", resp.StatusCode)
 	}
+
 	defer func(Body io.ReadCloser) {
 		bodyErr := Body.Close()
 		if bodyErr != nil {

--- a/aptible/organizations.go
+++ b/aptible/organizations.go
@@ -1,0 +1,84 @@
+package aptible
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+type HALOrganization struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type HALOrganizationParent struct {
+	Organizations []HALOrganization `json:"organizations"`
+}
+
+type HALOrganizationResponse struct {
+	Embedded HALOrganizationParent `json:"_embedded"`
+}
+
+type Organization struct {
+	ID   string
+	Name string
+}
+
+// getOrganizations - get all organizations a user has access to
+func (c *Client) getOrganizations() ([]Organization, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/organizations", GetAuthURL()), nil)
+	//Handle Error
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.RawToken))
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func(Body io.ReadCloser) {
+		bodyErr := Body.Close()
+		if bodyErr != nil {
+			log.Fatalf("Error in body reader close of http client %s\n", err.Error())
+		}
+	}(resp.Body)
+
+	out := HALOrganizationResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	orgs := make([]Organization, len(out.Embedded.Organizations))
+	for orgIdx, org := range out.Embedded.Organizations {
+		orgs[orgIdx] = Organization{
+			ID:   org.ID,
+			Name: org.Name,
+		}
+	}
+
+	return orgs, nil
+}
+
+// GetOrganization get organizations by user's token. Attempts to get organizations from auth api, then
+// attempts to get the FIRST one. if more than one is found or none are found, error is raised
+func (c *Client) GetOrganization() (Organization, error) {
+	organizations, err := c.getOrganizations()
+	if err != nil {
+		return Organization{}, err
+	}
+	if len(organizations) > 1 {
+		return Organization{}, fmt.Errorf("multiple organizations for user, unable to determine" +
+			" a default organization in result")
+	}
+
+	if len(organizations) == 0 {
+		return Organization{}, fmt.Errorf("no organizations found in response")
+	}
+
+	return organizations[0], nil
+}

--- a/aptible/organizations.go
+++ b/aptible/organizations.go
@@ -8,22 +8,17 @@ import (
 	"net/http"
 )
 
-type HALOrganization struct {
+type Organization struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
 type HALOrganizationParent struct {
-	Organizations []HALOrganization `json:"organizations"`
+	Organizations []Organization `json:"organizations"`
 }
 
 type HALOrganizationResponse struct {
 	Embedded HALOrganizationParent `json:"_embedded"`
-}
-
-type Organization struct {
-	ID   string
-	Name string
 }
 
 // getOrganizations - get all organizations a user has access to
@@ -53,15 +48,7 @@ func (c *Client) getOrganizations() ([]Organization, error) {
 		return nil, err
 	}
 
-	orgs := make([]Organization, len(out.Embedded.Organizations))
-	for orgIdx, org := range out.Embedded.Organizations {
-		orgs[orgIdx] = Organization{
-			ID:   org.ID,
-			Name: org.Name,
-		}
-	}
-
-	return orgs, nil
+	return out.Embedded.Organizations, nil
 }
 
 // GetOrganization get organizations by user's token. Attempts to get organizations from auth api, then

--- a/aptible/tokens.go
+++ b/aptible/tokens.go
@@ -62,13 +62,18 @@ func loginWithUsernameAndPassword(authUrl, user, password string) (string, error
 	return output["access_token"].(string), nil
 }
 
-// GetToken - gets a token (or error) for use from username password, an environment variable or filesystem
-func GetToken() (string, error) {
+func GetAuthURL() string {
 	// Gets auth server
 	auth := os.Getenv("APTIBLE_AUTH_ROOT_URL")
 	if auth == "" {
 		auth = "https://auth.aptible.com"
 	}
+	return auth
+}
+
+// GetToken - gets a token (or error) for use from username password, an environment variable or filesystem
+func GetToken() (string, error) {
+	auth := GetAuthURL()
 
 	// use auth-server to get tokens
 	user := os.Getenv("APTIBLE_USERNAME")

--- a/test/integration/organizations_test.go
+++ b/test/integration/organizations_test.go
@@ -1,0 +1,26 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOrganization(t *testing.T) {
+	client := getClient(t)
+
+	resp, err := client.GetOrganization()
+	if err != nil {
+		t.Fatalf("Error when trying to get organization - %s", err.Error())
+		return
+	}
+	if resp.ID == "" {
+		t.Fatal("Error when retrieving organization, id not populated")
+		return
+	}
+
+	fmt.Println("Organization ID retrieved", resp.ID)
+	fmt.Println("Organization Name retrieved", resp.Name)
+}


### PR DESCRIPTION
This does the following:

* get organizations by user's token
* if above succeeds, attempts to get organizations from auth api
* if above succeeds, attempts to get the FIRST one. if more than one is found or none are found, error is raised

---

failure conditions not tested very well

TODO 

- [x] test unhappy path (add an extra org in auth) - screenshot below

---

Ran against sandbox stack (happy path):

<img width="590" alt="image" src="https://user-images.githubusercontent.com/2961973/197868192-c74a59fe-58fa-4efb-b65d-aaf002db5884.png">

Was able to hit 1 of 2 unhappy paths (2nd might be impossible):

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/2961973/197885223-8edfc2a1-e0bb-4585-8116-01da1a5757ac.png">
