### PR TITLE
chore: added more messaging to multi-org messages (ids/names)

### DIFF
--- a/aptible/organizations.go
+++ b/aptible/organizations.go
@@ -62,8 +62,16 @@ func (c *Client) GetOrganization() (Organization, error) {
 		return Organization{}, err
 	}
 	if len(organizations) > 1 {
-		return Organization{}, fmt.Errorf("multiple organizations for user, unable to determine" +
-			" a default organization in result")
+		var organizationsErrorString string
+		for idx, organization := range organizations {
+			organizationsErrorString += fmt.Sprintf("%s (org_id: %s)", organization.Name, organization.ID)
+			if idx != len(organizations)-1 {
+				organizationsErrorString += ", "
+			}
+		}
+
+		return Organization{}, fmt.Errorf("multiple organizations for user, unable to determine"+
+			" a default organization in result. Organizations found: %s", organizationsErrorString)
 	}
 
 	if len(organizations) == 0 {


### PR DESCRIPTION
Forgot to include names/ids on orgs' error message as requested in an affixed bullet point.  Example error message here, which should bubble up to the end user via client:

<img width="1843" alt="image" src="https://user-images.githubusercontent.com/2961973/198161221-91de25e0-c394-4474-8959-5c7626c5db70.png">
