### PR TITLE
Make m5 the default instance class

### DIFF
--- a/aptible/database.go
+++ b/aptible/database.go
@@ -87,7 +87,7 @@ func (c *Client) CreateDatabase(accountID int64, attrs DBCreateAttrs) (Database,
 
 	// Setting the container profile on provision is not currently supported so
 	// if a non-default container profile is requested, restart with the desired profile
-	if attrs.ContainerProfile != "" && attrs.ContainerProfile != "m4" {
+	if attrs.ContainerProfile != "" && attrs.ContainerProfile != "m5" {
 		requestType := "restart"
 		request := models.AppRequest24{
 			Type:            &requestType,


### PR DESCRIPTION
If a database was provisioned with anything other than m4, it got an extra restart after provision (since we don't yet support provisioning with an instance class). This PR just changes the m4 to m5 to support our new upcoming default.