### PR TITLE
Remove .com requirement from APTIBLE_API_ROOT_URL url

### DIFF
--- a/aptible/client.go
+++ b/aptible/client.go
@@ -47,7 +47,7 @@ func SetUpClient() (*Client, error) {
 	return &c, nil
 }
 
-// Gets host from env var, ensures it ends in ".com", or sets default.
+// Gets host from env var or sets default.
 func GetHost() (string, error) {
 	host, ok := os.LookupEnv("APTIBLE_API_ROOT_URL")
 	if !ok {
@@ -59,7 +59,7 @@ func GetHost() (string, error) {
 	host = strings.TrimPrefix(host, "https://")
 
 	if !validHost(host) {
-		return "", fmt.Errorf("[ERROR] Host must be of the form xxx.xxx.com. Inputted host: %s", host)
+		return "", fmt.Errorf("[ERROR] Host must be of the form xxx.xxx.xxx. Inputted host: %s", host)
 	}
 
 	return host, nil
@@ -67,7 +67,7 @@ func GetHost() (string, error) {
 
 func validHost(host string) bool {
 	re, _ := regexp.Compile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
-	if re.MatchString(host) && strings.HasSuffix(host, ".com") {
+	if re.MatchString(host) {
 		return true
 	}
 	return false

--- a/aptible/client.go
+++ b/aptible/client.go
@@ -67,8 +67,5 @@ func GetHost() (string, error) {
 
 func validHost(host string) bool {
 	re, _ := regexp.Compile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
-	if re.MatchString(host) {
-		return true
-	}
-	return false
+	return re.MatchString(host)
 }

--- a/aptible/client_test.go
+++ b/aptible/client_test.go
@@ -17,6 +17,7 @@ func TestGetHost(t *testing.T) {
 		{"https://api.aptible.com", "api.aptible.com", false},
 		{"http://api.aptible.com", "api.aptible.com", false},
 		{"api.aptible.com", "api.aptible.com", false},
+		{"api.aptible.in", "api.aptible.in", false},
 		{"api.aptible", "", true},
 		{"www.api.aptible.c", "", true},
 		// Add other test cases if we need in the future

--- a/aptible/client_test.go
+++ b/aptible/client_test.go
@@ -18,8 +18,9 @@ func TestGetHost(t *testing.T) {
 		{"http://api.aptible.com", "api.aptible.com", false},
 		{"api.aptible.com", "api.aptible.com", false},
 		{"api.aptible.in", "api.aptible.in", false},
-		{"api.aptible", "", true},
-		{"www.api.aptible.c", "", true},
+		{"api.aptible", "api.aptible", false},
+		{"www.api.aptible.c", "www.api.aptible.c", false},
+		{"www.aptible_api.com", "", true},
 		// Add other test cases if we need in the future
 	}
 


### PR DESCRIPTION
This is stopping terraform acceptance tests from working when run against stacks using a non .com domain, like we do for our BYO sandbox stacks. Also terraform makes it really hard to determine what the error is since providers are run as their own service 🤦.