### PR TITLE
Add missing metric drain config attrs

### DIFF
--- a/aptible/metric_drain.go
+++ b/aptible/metric_drain.go
@@ -22,6 +22,9 @@ type MetricDrain struct {
 	APIKey     string
 	SeriesURL  strfmt.URI
 	AccountID  int64
+	AuthToken  string
+	Bucket     string
+	Org        string
 }
 
 type MetricDrainCreateAttrs struct {
@@ -34,6 +37,9 @@ type MetricDrainCreateAttrs struct {
 	Database     string
 	APIKey       string
 	SeriesURL    strfmt.URI
+	AuthToken    string
+	Bucket       string
+	Org          string
 }
 
 func (c *Client) CreateMetricDrain(handle string, accountID int64, attrs *MetricDrainCreateAttrs) (*MetricDrain, error) {
@@ -56,6 +62,9 @@ func (c *Client) CreateMetricDrain(handle string, accountID int64, attrs *Metric
 			Database:  attrs.Database,
 			APIKey:    attrs.APIKey,
 			SeriesURL: attrs.SeriesURL,
+			AuthToken: attrs.AuthToken,
+			Bucket:    attrs.Bucket,
+			Org:       attrs.Org,
 		}
 	}
 
@@ -130,6 +139,9 @@ func (c *Client) GetMetricDrain(metricDrainID int64) (*MetricDrain, error) {
 		metricDrain.Database = response.Payload.DrainConfiguration.Database
 		metricDrain.APIKey = response.Payload.DrainConfiguration.APIKey
 		metricDrain.SeriesURL = response.Payload.DrainConfiguration.SeriesURL
+		metricDrain.AuthToken = response.Payload.DrainConfiguration.AuthToken
+		metricDrain.Bucket = response.Payload.DrainConfiguration.Bucket
+		metricDrain.Org = response.Payload.DrainConfiguration.Org
 	}
 
 	if response.Payload.Links.Database != nil {

--- a/models/accountsaccount_idmetric_drains_drain_configuration.go
+++ b/models/accountsaccount_idmetric_drains_drain_configuration.go
@@ -36,6 +36,12 @@ type AccountsaccountIdmetricDrainsDrainConfiguration struct {
 
 	// username
 	Username string `json:"username,omitempty"`
+
+	AuthToken string `json:"authToken,omitempty"`
+
+	Bucket string `json:"bucket,omitempty"`
+
+	Org string `json:"org,omitempty"`
 }
 
 // Validate validates this accountsaccount idmetric drains drain configuration

--- a/models/inline_response20029_embedded_drain_configuration.go
+++ b/models/inline_response20029_embedded_drain_configuration.go
@@ -36,6 +36,12 @@ type InlineResponse20029EmbeddedDrainConfiguration struct {
 
 	// username
 	Username string `json:"username,omitempty"`
+
+	AuthToken string `json:"authToken,omitempty"`
+
+	Bucket string `json:"bucket,omitempty"`
+
+	Org string `json:"org,omitempty"`
 }
 
 // Validate validates this inline response 200 29 embedded drain configuration


### PR DESCRIPTION
Yes, I'm editing auto-generated code, but this repo is deprecated and I did add the attributes to Swagger (https://github.com/aptible/deploy-api/pull/1648) for the future

This change was tested by manually editing the vendored files in `terraform-provider-aptible` and using `TF_ACC=1 [SNIPPED] test -run "^(TestAccResourceMetricDrain_.*)$" github.com/aptible/terraform-provider-aptible/aptible`


![image](https://github.com/user-attachments/assets/954aea18-629b-42c0-8b1e-ad186223a50b)
