### PR TITLE
[SC-37908] Remove http+elb code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.13'
+          go-version: '1.26'
 
       - name: Setup
         run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,7 +51,7 @@ lint:
 	@./bin/golangci-lint run
 
 tools:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.24.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.0
 	@scripts/install-swagger.sh
 
 .PHONY: build gen gen-native gen-m1 test testapi test-integration fmt fmtcheck lint tools

--- a/aptible/client.go
+++ b/aptible/client.go
@@ -45,7 +45,7 @@ func SetUpClient() (*Client, error) {
 	rt.Producers["application/hal+json"] = runtime.JSONProducer()
 	rt.Transport = &userAgentTransport{
 		wrapped:   http.DefaultTransport,
-		userAgent: "aptible/go-deploy/" + version(),
+		userAgent: userAgent(),
 	}
 	client := deploy.New(rt, strfmt.Default)
 

--- a/aptible/client.go
+++ b/aptible/client.go
@@ -2,6 +2,7 @@ package aptible
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -11,6 +12,17 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
+
+type userAgentTransport struct {
+	wrapped   http.RoundTripper
+	userAgent string
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", t.userAgent)
+	return t.wrapped.RoundTrip(req)
+}
 
 type Client struct {
 	Client   *deploy.DeployAPIV1
@@ -31,6 +43,10 @@ func SetUpClient() (*Client, error) {
 		deploy.DefaultSchemes)
 	rt.Consumers["application/hal+json"] = runtime.JSONConsumer()
 	rt.Producers["application/hal+json"] = runtime.JSONProducer()
+	rt.Transport = &userAgentTransport{
+		wrapped:   http.DefaultTransport,
+		userAgent: "aptible/go-deploy/" + version(),
+	}
 	client := deploy.New(rt, strfmt.Default)
 
 	token, err := GetToken()

--- a/aptible/database.go
+++ b/aptible/database.go
@@ -25,7 +25,8 @@ type Database struct {
 }
 
 // DBUpdates - struct to define what operations you contain your DB update to. Add values to this struct
-// 			   to eventually pass it around for consumption by the go sdk
+//
+//	to eventually pass it around for consumption by the go sdk
 type DBUpdates struct {
 	ContainerSize    int64
 	DiskSize         int64

--- a/aptible/endpoints.go
+++ b/aptible/endpoints.go
@@ -68,7 +68,7 @@ func (c *Client) CreateEndpoint(service Service, attrs EndpointCreateAttrs) (End
 		request.ContainerPort = attrs.ContainerPort
 	}
 
-	if *attrs.Type != "http_proxy_protocol" && *attrs.Type != "http" && *attrs.Type != "grpc" {
+	if *attrs.Type != "http" && *attrs.Type != "grpc" {
 		request.ContainerPorts = attrs.ContainerPorts
 	}
 
@@ -280,7 +280,7 @@ func (c *Client) DeleteEndpoint(endpointID int64) error {
 func GetEndpointType(t string) (string, error) {
 	switch t {
 	case "HTTPS", "https":
-		return "http_proxy_protocol", nil
+		return "http", nil
 	case "TCP", "tcp":
 		return "tcp", nil
 	case "TLS", "tls":
@@ -295,7 +295,7 @@ func GetEndpointType(t string) (string, error) {
 
 func GetHumanReadableEndpointType(t string) (string, error) {
 	switch t {
-	case "http_proxy_protocol":
+	case "http_proxy_protocol", "http":
 		return "https", nil
 	case "tcp":
 		return "tcp", nil

--- a/aptible/tokens.go
+++ b/aptible/tokens.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // loginWithUsernameAndPassword - specifically requests APTIBLE_AUTH_ROOT_URL for token with a username/password
@@ -88,7 +86,7 @@ func GetToken() (string, error) {
 		return token, nil
 	}
 
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("Your token is invalid. Are you logged in? Error: %v", err.Error())
 	}

--- a/aptible/tokens_test.go
+++ b/aptible/tokens_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 func mockEnv(envVar, value string) func() {
@@ -39,7 +37,6 @@ func TestGetTokenEnv(t *testing.T) {
 }
 
 func TestGetToken(t *testing.T) {
-	homedir.DisableCache = true
 	tmpHome, err := ioutil.TempDir(os.TempDir(), "go-deploy")
 	if err != nil {
 		t.Error("Failed to create the temp directory", err)

--- a/aptible/version.go
+++ b/aptible/version.go
@@ -9,9 +9,13 @@ func version() string {
 				return dep.Version
 			}
 		}
-		if info.Main.Version != "" {
+		if info.Main.Path == "github.com/aptible/go-deploy" {
 			return info.Main.Version
 		}
 	}
-	return "aptible/go-deploy/unknown"
+	return "unknown"
+}
+
+func userAgent() string {
+	return "aptible/go-deploy/" + version()
 }

--- a/aptible/version.go
+++ b/aptible/version.go
@@ -1,0 +1,10 @@
+package aptible
+
+import "runtime/debug"
+
+func version() string {
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		return info.Main.Version
+	}
+	return "unknown"
+}

--- a/aptible/version.go
+++ b/aptible/version.go
@@ -3,8 +3,12 @@ package aptible
 import "runtime/debug"
 
 func version() string {
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
-		return info.Main.Version
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/aptible/go-deploy" {
+				return dep.Version
+			}
+		}
 	}
 	return "unknown"
 }

--- a/aptible/version.go
+++ b/aptible/version.go
@@ -9,6 +9,9 @@ func version() string {
 				return dep.Version
 			}
 		}
+		if info.Main.Version != "" {
+			return info.Main.Version
+		}
 	}
-	return "unknown"
+	return "aptible/go-deploy/unknown"
 }

--- a/aptible/version_test.go
+++ b/aptible/version_test.go
@@ -1,0 +1,10 @@
+package aptible
+
+import "testing"
+
+func TestVersion(t *testing.T) {
+	v := version()
+	if v == "aptible/go-deploy/unknown" {
+		t.Errorf("version() returned %q", v)
+	}
+}

--- a/aptible/version_test.go
+++ b/aptible/version_test.go
@@ -4,7 +4,15 @@ import "testing"
 
 func TestVersion(t *testing.T) {
 	v := version()
-	if v == "aptible/go-deploy/unknown" {
+	if v == "unknown" {
 		t.Errorf("version() returned %q", v)
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	ua := userAgent()
+	expected := "aptible/go-deploy/" + version()
+	if ua != expected {
+		t.Errorf("userAgent() = %q, want %q", ua, expected)
 	}
 }

--- a/client/operations/delete_accounts_id_parameters.go
+++ b/client/operations/delete_accounts_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteAccountsIDParamsWithHTTPClient(client *http.Client) *DeleteAccount
 	}
 }
 
-/*DeleteAccountsIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteAccountsIDParams contains all the parameters to send to the API endpoint
 for the delete accounts ID operation typically these are written to a http.Request
 */
 type DeleteAccountsIDParams struct {

--- a/client/operations/delete_accounts_id_responses.go
+++ b/client/operations/delete_accounts_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteAccountsIDNoContent() *DeleteAccountsIDNoContent {
 	return &DeleteAccountsIDNoContent{}
 }
 
-/*DeleteAccountsIDNoContent handles this case with default header values.
+/*
+DeleteAccountsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteAccountsIDDefault(code int) *DeleteAccountsIDDefault {
 	}
 }
 
-/*DeleteAccountsIDDefault handles this case with default header values.
+/*
+DeleteAccountsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_apps_id_parameters.go
+++ b/client/operations/delete_apps_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteAppsIDParamsWithHTTPClient(client *http.Client) *DeleteAppsIDParam
 	}
 }
 
-/*DeleteAppsIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteAppsIDParams contains all the parameters to send to the API endpoint
 for the delete apps ID operation typically these are written to a http.Request
 */
 type DeleteAppsIDParams struct {

--- a/client/operations/delete_apps_id_responses.go
+++ b/client/operations/delete_apps_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteAppsIDNoContent() *DeleteAppsIDNoContent {
 	return &DeleteAppsIDNoContent{}
 }
 
-/*DeleteAppsIDNoContent handles this case with default header values.
+/*
+DeleteAppsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteAppsIDDefault(code int) *DeleteAppsIDDefault {
 	}
 }
 
-/*DeleteAppsIDDefault handles this case with default header values.
+/*
+DeleteAppsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_backup_retention_policies_id_parameters.go
+++ b/client/operations/delete_backup_retention_policies_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteBackupRetentionPoliciesIDParamsWithHTTPClient(client *http.Client)
 	}
 }
 
-/*DeleteBackupRetentionPoliciesIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteBackupRetentionPoliciesIDParams contains all the parameters to send to the API endpoint
 for the delete backup retention policies ID operation typically these are written to a http.Request
 */
 type DeleteBackupRetentionPoliciesIDParams struct {

--- a/client/operations/delete_backup_retention_policies_id_responses.go
+++ b/client/operations/delete_backup_retention_policies_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteBackupRetentionPoliciesIDNoContent() *DeleteBackupRetentionPolicie
 	return &DeleteBackupRetentionPoliciesIDNoContent{}
 }
 
-/*DeleteBackupRetentionPoliciesIDNoContent handles this case with default header values.
+/*
+DeleteBackupRetentionPoliciesIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteBackupRetentionPoliciesIDDefault(code int) *DeleteBackupRetentionP
 	}
 }
 
-/*DeleteBackupRetentionPoliciesIDDefault handles this case with default header values.
+/*
+DeleteBackupRetentionPoliciesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_certificates_id_parameters.go
+++ b/client/operations/delete_certificates_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteCertificatesIDParamsWithHTTPClient(client *http.Client) *DeleteCer
 	}
 }
 
-/*DeleteCertificatesIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteCertificatesIDParams contains all the parameters to send to the API endpoint
 for the delete certificates ID operation typically these are written to a http.Request
 */
 type DeleteCertificatesIDParams struct {

--- a/client/operations/delete_certificates_id_responses.go
+++ b/client/operations/delete_certificates_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteCertificatesIDNoContent() *DeleteCertificatesIDNoContent {
 	return &DeleteCertificatesIDNoContent{}
 }
 
-/*DeleteCertificatesIDNoContent handles this case with default header values.
+/*
+DeleteCertificatesIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteCertificatesIDDefault(code int) *DeleteCertificatesIDDefault {
 	}
 }
 
-/*DeleteCertificatesIDDefault handles this case with default header values.
+/*
+DeleteCertificatesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_configurations_id_parameters.go
+++ b/client/operations/delete_configurations_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteConfigurationsIDParamsWithHTTPClient(client *http.Client) *DeleteC
 	}
 }
 
-/*DeleteConfigurationsIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteConfigurationsIDParams contains all the parameters to send to the API endpoint
 for the delete configurations ID operation typically these are written to a http.Request
 */
 type DeleteConfigurationsIDParams struct {

--- a/client/operations/delete_configurations_id_responses.go
+++ b/client/operations/delete_configurations_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteConfigurationsIDNoContent() *DeleteConfigurationsIDNoContent {
 	return &DeleteConfigurationsIDNoContent{}
 }
 
-/*DeleteConfigurationsIDNoContent handles this case with default header values.
+/*
+DeleteConfigurationsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteConfigurationsIDDefault(code int) *DeleteConfigurationsIDDefault {
 	}
 }
 
-/*DeleteConfigurationsIDDefault handles this case with default header values.
+/*
+DeleteConfigurationsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_databases_id_parameters.go
+++ b/client/operations/delete_databases_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteDatabasesIDParamsWithHTTPClient(client *http.Client) *DeleteDataba
 	}
 }
 
-/*DeleteDatabasesIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteDatabasesIDParams contains all the parameters to send to the API endpoint
 for the delete databases ID operation typically these are written to a http.Request
 */
 type DeleteDatabasesIDParams struct {

--- a/client/operations/delete_databases_id_responses.go
+++ b/client/operations/delete_databases_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteDatabasesIDNoContent() *DeleteDatabasesIDNoContent {
 	return &DeleteDatabasesIDNoContent{}
 }
 
-/*DeleteDatabasesIDNoContent handles this case with default header values.
+/*
+DeleteDatabasesIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteDatabasesIDDefault(code int) *DeleteDatabasesIDDefault {
 	}
 }
 
-/*DeleteDatabasesIDDefault handles this case with default header values.
+/*
+DeleteDatabasesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_log_drains_id_parameters.go
+++ b/client/operations/delete_log_drains_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteLogDrainsIDParamsWithHTTPClient(client *http.Client) *DeleteLogDra
 	}
 }
 
-/*DeleteLogDrainsIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteLogDrainsIDParams contains all the parameters to send to the API endpoint
 for the delete log drains ID operation typically these are written to a http.Request
 */
 type DeleteLogDrainsIDParams struct {

--- a/client/operations/delete_log_drains_id_responses.go
+++ b/client/operations/delete_log_drains_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteLogDrainsIDNoContent() *DeleteLogDrainsIDNoContent {
 	return &DeleteLogDrainsIDNoContent{}
 }
 
-/*DeleteLogDrainsIDNoContent handles this case with default header values.
+/*
+DeleteLogDrainsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteLogDrainsIDDefault(code int) *DeleteLogDrainsIDDefault {
 	}
 }
 
-/*DeleteLogDrainsIDDefault handles this case with default header values.
+/*
+DeleteLogDrainsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_permissions_id_parameters.go
+++ b/client/operations/delete_permissions_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeletePermissionsIDParamsWithHTTPClient(client *http.Client) *DeletePerm
 	}
 }
 
-/*DeletePermissionsIDParams contains all the parameters to send to the API endpoint
+/*
+DeletePermissionsIDParams contains all the parameters to send to the API endpoint
 for the delete permissions ID operation typically these are written to a http.Request
 */
 type DeletePermissionsIDParams struct {

--- a/client/operations/delete_permissions_id_responses.go
+++ b/client/operations/delete_permissions_id_responses.go
@@ -47,7 +47,8 @@ func NewDeletePermissionsIDNoContent() *DeletePermissionsIDNoContent {
 	return &DeletePermissionsIDNoContent{}
 }
 
-/*DeletePermissionsIDNoContent handles this case with default header values.
+/*
+DeletePermissionsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeletePermissionsIDDefault(code int) *DeletePermissionsIDDefault {
 	}
 }
 
-/*DeletePermissionsIDDefault handles this case with default header values.
+/*
+DeletePermissionsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/delete_vhosts_id_parameters.go
+++ b/client/operations/delete_vhosts_id_parameters.go
@@ -57,7 +57,8 @@ func NewDeleteVhostsIDParamsWithHTTPClient(client *http.Client) *DeleteVhostsIDP
 	}
 }
 
-/*DeleteVhostsIDParams contains all the parameters to send to the API endpoint
+/*
+DeleteVhostsIDParams contains all the parameters to send to the API endpoint
 for the delete vhosts ID operation typically these are written to a http.Request
 */
 type DeleteVhostsIDParams struct {

--- a/client/operations/delete_vhosts_id_responses.go
+++ b/client/operations/delete_vhosts_id_responses.go
@@ -47,7 +47,8 @@ func NewDeleteVhostsIDNoContent() *DeleteVhostsIDNoContent {
 	return &DeleteVhostsIDNoContent{}
 }
 
-/*DeleteVhostsIDNoContent handles this case with default header values.
+/*
+DeleteVhostsIDNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewDeleteVhostsIDDefault(code int) *DeleteVhostsIDDefault {
 	}
 }
 
-/*DeleteVhostsIDDefault handles this case with default header values.
+/*
+DeleteVhostsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_activity_reports_parameters.go
+++ b/client/operations/get_accounts_account_id_activity_reports_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDActivityReportsParamsWithHTTPClient(client *http.Cli
 	}
 }
 
-/*GetAccountsAccountIDActivityReportsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDActivityReportsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID activity reports operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDActivityReportsParams struct {

--- a/client/operations/get_accounts_account_id_activity_reports_responses.go
+++ b/client/operations/get_accounts_account_id_activity_reports_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDActivityReportsOK() *GetAccountsAccountIDActivityRep
 	return &GetAccountsAccountIDActivityReportsOK{}
 }
 
-/*GetAccountsAccountIDActivityReportsOK handles this case with default header values.
+/*
+GetAccountsAccountIDActivityReportsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDActivityReportsDefault(code int) *GetAccountsAccount
 	}
 }
 
-/*GetAccountsAccountIDActivityReportsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDActivityReportsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_apps_parameters.go
+++ b/client/operations/get_accounts_account_id_apps_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDAppsParamsWithHTTPClient(client *http.Client) *GetAc
 	}
 }
 
-/*GetAccountsAccountIDAppsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDAppsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID apps operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDAppsParams struct {

--- a/client/operations/get_accounts_account_id_apps_responses.go
+++ b/client/operations/get_accounts_account_id_apps_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDAppsOK() *GetAccountsAccountIDAppsOK {
 	return &GetAccountsAccountIDAppsOK{}
 }
 
-/*GetAccountsAccountIDAppsOK handles this case with default header values.
+/*
+GetAccountsAccountIDAppsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDAppsDefault(code int) *GetAccountsAccountIDAppsDefau
 	}
 }
 
-/*GetAccountsAccountIDAppsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDAppsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_backup_retention_policies_parameters.go
+++ b/client/operations/get_accounts_account_id_backup_retention_policies_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDBackupRetentionPoliciesParamsWithHTTPClient(client *
 	}
 }
 
-/*GetAccountsAccountIDBackupRetentionPoliciesParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDBackupRetentionPoliciesParams contains all the parameters to send to the API endpoint
 for the get accounts account ID backup retention policies operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDBackupRetentionPoliciesParams struct {

--- a/client/operations/get_accounts_account_id_backup_retention_policies_responses.go
+++ b/client/operations/get_accounts_account_id_backup_retention_policies_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDBackupRetentionPoliciesOK() *GetAccountsAccountIDBac
 	return &GetAccountsAccountIDBackupRetentionPoliciesOK{}
 }
 
-/*GetAccountsAccountIDBackupRetentionPoliciesOK handles this case with default header values.
+/*
+GetAccountsAccountIDBackupRetentionPoliciesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDBackupRetentionPoliciesDefault(code int) *GetAccount
 	}
 }
 
-/*GetAccountsAccountIDBackupRetentionPoliciesDefault handles this case with default header values.
+/*
+GetAccountsAccountIDBackupRetentionPoliciesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_backups_parameters.go
+++ b/client/operations/get_accounts_account_id_backups_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDBackupsParamsWithHTTPClient(client *http.Client) *Ge
 	}
 }
 
-/*GetAccountsAccountIDBackupsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDBackupsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID backups operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDBackupsParams struct {

--- a/client/operations/get_accounts_account_id_backups_responses.go
+++ b/client/operations/get_accounts_account_id_backups_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDBackupsOK() *GetAccountsAccountIDBackupsOK {
 	return &GetAccountsAccountIDBackupsOK{}
 }
 
-/*GetAccountsAccountIDBackupsOK handles this case with default header values.
+/*
+GetAccountsAccountIDBackupsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDBackupsDefault(code int) *GetAccountsAccountIDBackup
 	}
 }
 
-/*GetAccountsAccountIDBackupsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDBackupsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_certificates_parameters.go
+++ b/client/operations/get_accounts_account_id_certificates_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDCertificatesParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetAccountsAccountIDCertificatesParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDCertificatesParams contains all the parameters to send to the API endpoint
 for the get accounts account ID certificates operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDCertificatesParams struct {

--- a/client/operations/get_accounts_account_id_certificates_responses.go
+++ b/client/operations/get_accounts_account_id_certificates_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDCertificatesOK() *GetAccountsAccountIDCertificatesOK
 	return &GetAccountsAccountIDCertificatesOK{}
 }
 
-/*GetAccountsAccountIDCertificatesOK handles this case with default header values.
+/*
+GetAccountsAccountIDCertificatesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDCertificatesDefault(code int) *GetAccountsAccountIDC
 	}
 }
 
-/*GetAccountsAccountIDCertificatesDefault handles this case with default header values.
+/*
+GetAccountsAccountIDCertificatesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_databases_parameters.go
+++ b/client/operations/get_accounts_account_id_databases_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDDatabasesParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/*GetAccountsAccountIDDatabasesParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDDatabasesParams contains all the parameters to send to the API endpoint
 for the get accounts account ID databases operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDDatabasesParams struct {

--- a/client/operations/get_accounts_account_id_databases_responses.go
+++ b/client/operations/get_accounts_account_id_databases_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDDatabasesOK() *GetAccountsAccountIDDatabasesOK {
 	return &GetAccountsAccountIDDatabasesOK{}
 }
 
-/*GetAccountsAccountIDDatabasesOK handles this case with default header values.
+/*
+GetAccountsAccountIDDatabasesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDDatabasesDefault(code int) *GetAccountsAccountIDData
 	}
 }
 
-/*GetAccountsAccountIDDatabasesDefault handles this case with default header values.
+/*
+GetAccountsAccountIDDatabasesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_disks_parameters.go
+++ b/client/operations/get_accounts_account_id_disks_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDDisksParamsWithHTTPClient(client *http.Client) *GetA
 	}
 }
 
-/*GetAccountsAccountIDDisksParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDDisksParams contains all the parameters to send to the API endpoint
 for the get accounts account ID disks operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDDisksParams struct {

--- a/client/operations/get_accounts_account_id_disks_responses.go
+++ b/client/operations/get_accounts_account_id_disks_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDDisksOK() *GetAccountsAccountIDDisksOK {
 	return &GetAccountsAccountIDDisksOK{}
 }
 
-/*GetAccountsAccountIDDisksOK handles this case with default header values.
+/*
+GetAccountsAccountIDDisksOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDDisksDefault(code int) *GetAccountsAccountIDDisksDef
 	}
 }
 
-/*GetAccountsAccountIDDisksDefault handles this case with default header values.
+/*
+GetAccountsAccountIDDisksDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_log_drains_parameters.go
+++ b/client/operations/get_accounts_account_id_log_drains_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDLogDrainsParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/*GetAccountsAccountIDLogDrainsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDLogDrainsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID log drains operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDLogDrainsParams struct {

--- a/client/operations/get_accounts_account_id_log_drains_responses.go
+++ b/client/operations/get_accounts_account_id_log_drains_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDLogDrainsOK() *GetAccountsAccountIDLogDrainsOK {
 	return &GetAccountsAccountIDLogDrainsOK{}
 }
 
-/*GetAccountsAccountIDLogDrainsOK handles this case with default header values.
+/*
+GetAccountsAccountIDLogDrainsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDLogDrainsDefault(code int) *GetAccountsAccountIDLogD
 	}
 }
 
-/*GetAccountsAccountIDLogDrainsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDLogDrainsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_metric_drains_parameters.go
+++ b/client/operations/get_accounts_account_id_metric_drains_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDMetricDrainsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetAccountsAccountIDMetricDrainsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDMetricDrainsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID metric drains operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDMetricDrainsParams struct {

--- a/client/operations/get_accounts_account_id_metric_drains_responses.go
+++ b/client/operations/get_accounts_account_id_metric_drains_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDMetricDrainsOK() *GetAccountsAccountIDMetricDrainsOK
 	return &GetAccountsAccountIDMetricDrainsOK{}
 }
 
-/*GetAccountsAccountIDMetricDrainsOK handles this case with default header values.
+/*
+GetAccountsAccountIDMetricDrainsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDMetricDrainsDefault(code int) *GetAccountsAccountIDM
 	}
 }
 
-/*GetAccountsAccountIDMetricDrainsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDMetricDrainsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_operations_parameters.go
+++ b/client/operations/get_accounts_account_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDOperationsParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*GetAccountsAccountIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDOperationsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID operations operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDOperationsParams struct {

--- a/client/operations/get_accounts_account_id_operations_responses.go
+++ b/client/operations/get_accounts_account_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDOperationsOK() *GetAccountsAccountIDOperationsOK {
 	return &GetAccountsAccountIDOperationsOK{}
 }
 
-/*GetAccountsAccountIDOperationsOK handles this case with default header values.
+/*
+GetAccountsAccountIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDOperationsDefault(code int) *GetAccountsAccountIDOpe
 	}
 }
 
-/*GetAccountsAccountIDOperationsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_permissions_parameters.go
+++ b/client/operations/get_accounts_account_id_permissions_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDPermissionsParamsWithHTTPClient(client *http.Client)
 	}
 }
 
-/*GetAccountsAccountIDPermissionsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDPermissionsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID permissions operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDPermissionsParams struct {

--- a/client/operations/get_accounts_account_id_permissions_responses.go
+++ b/client/operations/get_accounts_account_id_permissions_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDPermissionsOK() *GetAccountsAccountIDPermissionsOK {
 	return &GetAccountsAccountIDPermissionsOK{}
 }
 
-/*GetAccountsAccountIDPermissionsOK handles this case with default header values.
+/*
+GetAccountsAccountIDPermissionsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDPermissionsDefault(code int) *GetAccountsAccountIDPe
 	}
 }
 
-/*GetAccountsAccountIDPermissionsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDPermissionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_services_parameters.go
+++ b/client/operations/get_accounts_account_id_services_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDServicesParamsWithHTTPClient(client *http.Client) *G
 	}
 }
 
-/*GetAccountsAccountIDServicesParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDServicesParams contains all the parameters to send to the API endpoint
 for the get accounts account ID services operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDServicesParams struct {

--- a/client/operations/get_accounts_account_id_services_responses.go
+++ b/client/operations/get_accounts_account_id_services_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDServicesOK() *GetAccountsAccountIDServicesOK {
 	return &GetAccountsAccountIDServicesOK{}
 }
 
-/*GetAccountsAccountIDServicesOK handles this case with default header values.
+/*
+GetAccountsAccountIDServicesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDServicesDefault(code int) *GetAccountsAccountIDServi
 	}
 }
 
-/*GetAccountsAccountIDServicesDefault handles this case with default header values.
+/*
+GetAccountsAccountIDServicesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_account_id_vhosts_parameters.go
+++ b/client/operations/get_accounts_account_id_vhosts_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsAccountIDVhostsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetAccountsAccountIDVhostsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsAccountIDVhostsParams contains all the parameters to send to the API endpoint
 for the get accounts account ID vhosts operation typically these are written to a http.Request
 */
 type GetAccountsAccountIDVhostsParams struct {

--- a/client/operations/get_accounts_account_id_vhosts_responses.go
+++ b/client/operations/get_accounts_account_id_vhosts_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsAccountIDVhostsOK() *GetAccountsAccountIDVhostsOK {
 	return &GetAccountsAccountIDVhostsOK{}
 }
 
-/*GetAccountsAccountIDVhostsOK handles this case with default header values.
+/*
+GetAccountsAccountIDVhostsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsAccountIDVhostsDefault(code int) *GetAccountsAccountIDVhostsD
 	}
 }
 
-/*GetAccountsAccountIDVhostsDefault handles this case with default header values.
+/*
+GetAccountsAccountIDVhostsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_id_parameters.go
+++ b/client/operations/get_accounts_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsIDParamsWithHTTPClient(client *http.Client) *GetAccountsIDPar
 	}
 }
 
-/*GetAccountsIDParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsIDParams contains all the parameters to send to the API endpoint
 for the get accounts ID operation typically these are written to a http.Request
 */
 type GetAccountsIDParams struct {

--- a/client/operations/get_accounts_id_responses.go
+++ b/client/operations/get_accounts_id_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsIDOK() *GetAccountsIDOK {
 	return &GetAccountsIDOK{}
 }
 
-/*GetAccountsIDOK handles this case with default header values.
+/*
+GetAccountsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsIDDefault(code int) *GetAccountsIDDefault {
 	}
 }
 
-/*GetAccountsIDDefault handles this case with default header values.
+/*
+GetAccountsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_accounts_parameters.go
+++ b/client/operations/get_accounts_parameters.go
@@ -57,7 +57,8 @@ func NewGetAccountsParamsWithHTTPClient(client *http.Client) *GetAccountsParams 
 	}
 }
 
-/*GetAccountsParams contains all the parameters to send to the API endpoint
+/*
+GetAccountsParams contains all the parameters to send to the API endpoint
 for the get accounts operation typically these are written to a http.Request
 */
 type GetAccountsParams struct {

--- a/client/operations/get_accounts_responses.go
+++ b/client/operations/get_accounts_responses.go
@@ -47,7 +47,8 @@ func NewGetAccountsOK() *GetAccountsOK {
 	return &GetAccountsOK{}
 }
 
-/*GetAccountsOK handles this case with default header values.
+/*
+GetAccountsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAccountsDefault(code int) *GetAccountsDefault {
 	}
 }
 
-/*GetAccountsDefault handles this case with default header values.
+/*
+GetAccountsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_activity_reports_activity_report_id_download_parameters.go
+++ b/client/operations/get_activity_reports_activity_report_id_download_parameters.go
@@ -57,7 +57,8 @@ func NewGetActivityReportsActivityReportIDDownloadParamsWithHTTPClient(client *h
 	}
 }
 
-/*GetActivityReportsActivityReportIDDownloadParams contains all the parameters to send to the API endpoint
+/*
+GetActivityReportsActivityReportIDDownloadParams contains all the parameters to send to the API endpoint
 for the get activity reports activity report ID download operation typically these are written to a http.Request
 */
 type GetActivityReportsActivityReportIDDownloadParams struct {

--- a/client/operations/get_activity_reports_activity_report_id_download_responses.go
+++ b/client/operations/get_activity_reports_activity_report_id_download_responses.go
@@ -47,7 +47,8 @@ func NewGetActivityReportsActivityReportIDDownloadOK() *GetActivityReportsActivi
 	return &GetActivityReportsActivityReportIDDownloadOK{}
 }
 
-/*GetActivityReportsActivityReportIDDownloadOK handles this case with default header values.
+/*
+GetActivityReportsActivityReportIDDownloadOK handles this case with default header values.
 
 Presigned download URL
 */
@@ -70,7 +71,8 @@ func NewGetActivityReportsActivityReportIDDownloadDefault(code int) *GetActivity
 	}
 }
 
-/*GetActivityReportsActivityReportIDDownloadDefault handles this case with default header values.
+/*
+GetActivityReportsActivityReportIDDownloadDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_activity_reports_id_parameters.go
+++ b/client/operations/get_activity_reports_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetActivityReportsIDParamsWithHTTPClient(client *http.Client) *GetActivi
 	}
 }
 
-/*GetActivityReportsIDParams contains all the parameters to send to the API endpoint
+/*
+GetActivityReportsIDParams contains all the parameters to send to the API endpoint
 for the get activity reports ID operation typically these are written to a http.Request
 */
 type GetActivityReportsIDParams struct {

--- a/client/operations/get_activity_reports_id_responses.go
+++ b/client/operations/get_activity_reports_id_responses.go
@@ -47,7 +47,8 @@ func NewGetActivityReportsIDOK() *GetActivityReportsIDOK {
 	return &GetActivityReportsIDOK{}
 }
 
-/*GetActivityReportsIDOK handles this case with default header values.
+/*
+GetActivityReportsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetActivityReportsIDDefault(code int) *GetActivityReportsIDDefault {
 	}
 }
 
-/*GetActivityReportsIDDefault handles this case with default header values.
+/*
+GetActivityReportsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_configurations_parameters.go
+++ b/client/operations/get_apps_app_id_configurations_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDConfigurationsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetAppsAppIDConfigurationsParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDConfigurationsParams contains all the parameters to send to the API endpoint
 for the get apps app ID configurations operation typically these are written to a http.Request
 */
 type GetAppsAppIDConfigurationsParams struct {

--- a/client/operations/get_apps_app_id_configurations_responses.go
+++ b/client/operations/get_apps_app_id_configurations_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDConfigurationsOK() *GetAppsAppIDConfigurationsOK {
 	return &GetAppsAppIDConfigurationsOK{}
 }
 
-/*GetAppsAppIDConfigurationsOK handles this case with default header values.
+/*
+GetAppsAppIDConfigurationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDConfigurationsDefault(code int) *GetAppsAppIDConfigurationsD
 	}
 }
 
-/*GetAppsAppIDConfigurationsDefault handles this case with default header values.
+/*
+GetAppsAppIDConfigurationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_ephemeral_sessions_parameters.go
+++ b/client/operations/get_apps_app_id_ephemeral_sessions_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDEphemeralSessionsParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/*GetAppsAppIDEphemeralSessionsParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDEphemeralSessionsParams contains all the parameters to send to the API endpoint
 for the get apps app ID ephemeral sessions operation typically these are written to a http.Request
 */
 type GetAppsAppIDEphemeralSessionsParams struct {

--- a/client/operations/get_apps_app_id_ephemeral_sessions_responses.go
+++ b/client/operations/get_apps_app_id_ephemeral_sessions_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDEphemeralSessionsOK() *GetAppsAppIDEphemeralSessionsOK {
 	return &GetAppsAppIDEphemeralSessionsOK{}
 }
 
-/*GetAppsAppIDEphemeralSessionsOK handles this case with default header values.
+/*
+GetAppsAppIDEphemeralSessionsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDEphemeralSessionsDefault(code int) *GetAppsAppIDEphemeralSes
 	}
 }
 
-/*GetAppsAppIDEphemeralSessionsDefault handles this case with default header values.
+/*
+GetAppsAppIDEphemeralSessionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_images_parameters.go
+++ b/client/operations/get_apps_app_id_images_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDImagesParamsWithHTTPClient(client *http.Client) *GetAppsAppI
 	}
 }
 
-/*GetAppsAppIDImagesParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDImagesParams contains all the parameters to send to the API endpoint
 for the get apps app ID images operation typically these are written to a http.Request
 */
 type GetAppsAppIDImagesParams struct {

--- a/client/operations/get_apps_app_id_images_responses.go
+++ b/client/operations/get_apps_app_id_images_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDImagesOK() *GetAppsAppIDImagesOK {
 	return &GetAppsAppIDImagesOK{}
 }
 
-/*GetAppsAppIDImagesOK handles this case with default header values.
+/*
+GetAppsAppIDImagesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDImagesDefault(code int) *GetAppsAppIDImagesDefault {
 	}
 }
 
-/*GetAppsAppIDImagesDefault handles this case with default header values.
+/*
+GetAppsAppIDImagesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_operations_parameters.go
+++ b/client/operations/get_apps_app_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDOperationsParamsWithHTTPClient(client *http.Client) *GetApps
 	}
 }
 
-/*GetAppsAppIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDOperationsParams contains all the parameters to send to the API endpoint
 for the get apps app ID operations operation typically these are written to a http.Request
 */
 type GetAppsAppIDOperationsParams struct {

--- a/client/operations/get_apps_app_id_operations_responses.go
+++ b/client/operations/get_apps_app_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDOperationsOK() *GetAppsAppIDOperationsOK {
 	return &GetAppsAppIDOperationsOK{}
 }
 
-/*GetAppsAppIDOperationsOK handles this case with default header values.
+/*
+GetAppsAppIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDOperationsDefault(code int) *GetAppsAppIDOperationsDefault {
 	}
 }
 
-/*GetAppsAppIDOperationsDefault handles this case with default header values.
+/*
+GetAppsAppIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_services_parameters.go
+++ b/client/operations/get_apps_app_id_services_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDServicesParamsWithHTTPClient(client *http.Client) *GetAppsAp
 	}
 }
 
-/*GetAppsAppIDServicesParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDServicesParams contains all the parameters to send to the API endpoint
 for the get apps app ID services operation typically these are written to a http.Request
 */
 type GetAppsAppIDServicesParams struct {

--- a/client/operations/get_apps_app_id_services_responses.go
+++ b/client/operations/get_apps_app_id_services_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDServicesOK() *GetAppsAppIDServicesOK {
 	return &GetAppsAppIDServicesOK{}
 }
 
-/*GetAppsAppIDServicesOK handles this case with default header values.
+/*
+GetAppsAppIDServicesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDServicesDefault(code int) *GetAppsAppIDServicesDefault {
 	}
 }
 
-/*GetAppsAppIDServicesDefault handles this case with default header values.
+/*
+GetAppsAppIDServicesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_app_id_vhosts_parameters.go
+++ b/client/operations/get_apps_app_id_vhosts_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsAppIDVhostsParamsWithHTTPClient(client *http.Client) *GetAppsAppI
 	}
 }
 
-/*GetAppsAppIDVhostsParams contains all the parameters to send to the API endpoint
+/*
+GetAppsAppIDVhostsParams contains all the parameters to send to the API endpoint
 for the get apps app ID vhosts operation typically these are written to a http.Request
 */
 type GetAppsAppIDVhostsParams struct {

--- a/client/operations/get_apps_app_id_vhosts_responses.go
+++ b/client/operations/get_apps_app_id_vhosts_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsAppIDVhostsOK() *GetAppsAppIDVhostsOK {
 	return &GetAppsAppIDVhostsOK{}
 }
 
-/*GetAppsAppIDVhostsOK handles this case with default header values.
+/*
+GetAppsAppIDVhostsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsAppIDVhostsDefault(code int) *GetAppsAppIDVhostsDefault {
 	}
 }
 
-/*GetAppsAppIDVhostsDefault handles this case with default header values.
+/*
+GetAppsAppIDVhostsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_id_parameters.go
+++ b/client/operations/get_apps_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsIDParamsWithHTTPClient(client *http.Client) *GetAppsIDParams {
 	}
 }
 
-/*GetAppsIDParams contains all the parameters to send to the API endpoint
+/*
+GetAppsIDParams contains all the parameters to send to the API endpoint
 for the get apps ID operation typically these are written to a http.Request
 */
 type GetAppsIDParams struct {

--- a/client/operations/get_apps_id_responses.go
+++ b/client/operations/get_apps_id_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsIDOK() *GetAppsIDOK {
 	return &GetAppsIDOK{}
 }
 
-/*GetAppsIDOK handles this case with default header values.
+/*
+GetAppsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsIDDefault(code int) *GetAppsIDDefault {
 	}
 }
 
-/*GetAppsIDDefault handles this case with default header values.
+/*
+GetAppsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_apps_parameters.go
+++ b/client/operations/get_apps_parameters.go
@@ -57,7 +57,8 @@ func NewGetAppsParamsWithHTTPClient(client *http.Client) *GetAppsParams {
 	}
 }
 
-/*GetAppsParams contains all the parameters to send to the API endpoint
+/*
+GetAppsParams contains all the parameters to send to the API endpoint
 for the get apps operation typically these are written to a http.Request
 */
 type GetAppsParams struct {

--- a/client/operations/get_apps_responses.go
+++ b/client/operations/get_apps_responses.go
@@ -47,7 +47,8 @@ func NewGetAppsOK() *GetAppsOK {
 	return &GetAppsOK{}
 }
 
-/*GetAppsOK handles this case with default header values.
+/*
+GetAppsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetAppsDefault(code int) *GetAppsDefault {
 	}
 }
 
-/*GetAppsDefault handles this case with default header values.
+/*
+GetAppsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_backup_retention_policies_id_parameters.go
+++ b/client/operations/get_backup_retention_policies_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetBackupRetentionPoliciesIDParamsWithHTTPClient(client *http.Client) *G
 	}
 }
 
-/*GetBackupRetentionPoliciesIDParams contains all the parameters to send to the API endpoint
+/*
+GetBackupRetentionPoliciesIDParams contains all the parameters to send to the API endpoint
 for the get backup retention policies ID operation typically these are written to a http.Request
 */
 type GetBackupRetentionPoliciesIDParams struct {

--- a/client/operations/get_backup_retention_policies_id_responses.go
+++ b/client/operations/get_backup_retention_policies_id_responses.go
@@ -47,7 +47,8 @@ func NewGetBackupRetentionPoliciesIDOK() *GetBackupRetentionPoliciesIDOK {
 	return &GetBackupRetentionPoliciesIDOK{}
 }
 
-/*GetBackupRetentionPoliciesIDOK handles this case with default header values.
+/*
+GetBackupRetentionPoliciesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetBackupRetentionPoliciesIDDefault(code int) *GetBackupRetentionPolicie
 	}
 }
 
-/*GetBackupRetentionPoliciesIDDefault handles this case with default header values.
+/*
+GetBackupRetentionPoliciesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_backups_backup_id_copies_parameters.go
+++ b/client/operations/get_backups_backup_id_copies_parameters.go
@@ -57,7 +57,8 @@ func NewGetBackupsBackupIDCopiesParamsWithHTTPClient(client *http.Client) *GetBa
 	}
 }
 
-/*GetBackupsBackupIDCopiesParams contains all the parameters to send to the API endpoint
+/*
+GetBackupsBackupIDCopiesParams contains all the parameters to send to the API endpoint
 for the get backups backup ID copies operation typically these are written to a http.Request
 */
 type GetBackupsBackupIDCopiesParams struct {

--- a/client/operations/get_backups_backup_id_copies_responses.go
+++ b/client/operations/get_backups_backup_id_copies_responses.go
@@ -47,7 +47,8 @@ func NewGetBackupsBackupIDCopiesOK() *GetBackupsBackupIDCopiesOK {
 	return &GetBackupsBackupIDCopiesOK{}
 }
 
-/*GetBackupsBackupIDCopiesOK handles this case with default header values.
+/*
+GetBackupsBackupIDCopiesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetBackupsBackupIDCopiesDefault(code int) *GetBackupsBackupIDCopiesDefau
 	}
 }
 
-/*GetBackupsBackupIDCopiesDefault handles this case with default header values.
+/*
+GetBackupsBackupIDCopiesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_backups_backup_id_operations_parameters.go
+++ b/client/operations/get_backups_backup_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetBackupsBackupIDOperationsParamsWithHTTPClient(client *http.Client) *G
 	}
 }
 
-/*GetBackupsBackupIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetBackupsBackupIDOperationsParams contains all the parameters to send to the API endpoint
 for the get backups backup ID operations operation typically these are written to a http.Request
 */
 type GetBackupsBackupIDOperationsParams struct {

--- a/client/operations/get_backups_backup_id_operations_responses.go
+++ b/client/operations/get_backups_backup_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetBackupsBackupIDOperationsOK() *GetBackupsBackupIDOperationsOK {
 	return &GetBackupsBackupIDOperationsOK{}
 }
 
-/*GetBackupsBackupIDOperationsOK handles this case with default header values.
+/*
+GetBackupsBackupIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetBackupsBackupIDOperationsDefault(code int) *GetBackupsBackupIDOperati
 	}
 }
 
-/*GetBackupsBackupIDOperationsDefault handles this case with default header values.
+/*
+GetBackupsBackupIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_backups_id_parameters.go
+++ b/client/operations/get_backups_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetBackupsIDParamsWithHTTPClient(client *http.Client) *GetBackupsIDParam
 	}
 }
 
-/*GetBackupsIDParams contains all the parameters to send to the API endpoint
+/*
+GetBackupsIDParams contains all the parameters to send to the API endpoint
 for the get backups ID operation typically these are written to a http.Request
 */
 type GetBackupsIDParams struct {

--- a/client/operations/get_backups_id_responses.go
+++ b/client/operations/get_backups_id_responses.go
@@ -47,7 +47,8 @@ func NewGetBackupsIDOK() *GetBackupsIDOK {
 	return &GetBackupsIDOK{}
 }
 
-/*GetBackupsIDOK handles this case with default header values.
+/*
+GetBackupsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetBackupsIDDefault(code int) *GetBackupsIDDefault {
 	}
 }
 
-/*GetBackupsIDDefault handles this case with default header values.
+/*
+GetBackupsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_certificates_certificate_id_apps_parameters.go
+++ b/client/operations/get_certificates_certificate_id_apps_parameters.go
@@ -57,7 +57,8 @@ func NewGetCertificatesCertificateIDAppsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetCertificatesCertificateIDAppsParams contains all the parameters to send to the API endpoint
+/*
+GetCertificatesCertificateIDAppsParams contains all the parameters to send to the API endpoint
 for the get certificates certificate ID apps operation typically these are written to a http.Request
 */
 type GetCertificatesCertificateIDAppsParams struct {

--- a/client/operations/get_certificates_certificate_id_apps_responses.go
+++ b/client/operations/get_certificates_certificate_id_apps_responses.go
@@ -47,7 +47,8 @@ func NewGetCertificatesCertificateIDAppsOK() *GetCertificatesCertificateIDAppsOK
 	return &GetCertificatesCertificateIDAppsOK{}
 }
 
-/*GetCertificatesCertificateIDAppsOK handles this case with default header values.
+/*
+GetCertificatesCertificateIDAppsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetCertificatesCertificateIDAppsDefault(code int) *GetCertificatesCertif
 	}
 }
 
-/*GetCertificatesCertificateIDAppsDefault handles this case with default header values.
+/*
+GetCertificatesCertificateIDAppsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_certificates_certificate_id_vhosts_parameters.go
+++ b/client/operations/get_certificates_certificate_id_vhosts_parameters.go
@@ -57,7 +57,8 @@ func NewGetCertificatesCertificateIDVhostsParamsWithHTTPClient(client *http.Clie
 	}
 }
 
-/*GetCertificatesCertificateIDVhostsParams contains all the parameters to send to the API endpoint
+/*
+GetCertificatesCertificateIDVhostsParams contains all the parameters to send to the API endpoint
 for the get certificates certificate ID vhosts operation typically these are written to a http.Request
 */
 type GetCertificatesCertificateIDVhostsParams struct {

--- a/client/operations/get_certificates_certificate_id_vhosts_responses.go
+++ b/client/operations/get_certificates_certificate_id_vhosts_responses.go
@@ -47,7 +47,8 @@ func NewGetCertificatesCertificateIDVhostsOK() *GetCertificatesCertificateIDVhos
 	return &GetCertificatesCertificateIDVhostsOK{}
 }
 
-/*GetCertificatesCertificateIDVhostsOK handles this case with default header values.
+/*
+GetCertificatesCertificateIDVhostsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetCertificatesCertificateIDVhostsDefault(code int) *GetCertificatesCert
 	}
 }
 
-/*GetCertificatesCertificateIDVhostsDefault handles this case with default header values.
+/*
+GetCertificatesCertificateIDVhostsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_certificates_id_parameters.go
+++ b/client/operations/get_certificates_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetCertificatesIDParamsWithHTTPClient(client *http.Client) *GetCertifica
 	}
 }
 
-/*GetCertificatesIDParams contains all the parameters to send to the API endpoint
+/*
+GetCertificatesIDParams contains all the parameters to send to the API endpoint
 for the get certificates ID operation typically these are written to a http.Request
 */
 type GetCertificatesIDParams struct {

--- a/client/operations/get_certificates_id_responses.go
+++ b/client/operations/get_certificates_id_responses.go
@@ -47,7 +47,8 @@ func NewGetCertificatesIDOK() *GetCertificatesIDOK {
 	return &GetCertificatesIDOK{}
 }
 
-/*GetCertificatesIDOK handles this case with default header values.
+/*
+GetCertificatesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetCertificatesIDDefault(code int) *GetCertificatesIDDefault {
 	}
 }
 
-/*GetCertificatesIDDefault handles this case with default header values.
+/*
+GetCertificatesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_configurations_id_parameters.go
+++ b/client/operations/get_configurations_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetConfigurationsIDParamsWithHTTPClient(client *http.Client) *GetConfigu
 	}
 }
 
-/*GetConfigurationsIDParams contains all the parameters to send to the API endpoint
+/*
+GetConfigurationsIDParams contains all the parameters to send to the API endpoint
 for the get configurations ID operation typically these are written to a http.Request
 */
 type GetConfigurationsIDParams struct {

--- a/client/operations/get_configurations_id_responses.go
+++ b/client/operations/get_configurations_id_responses.go
@@ -47,7 +47,8 @@ func NewGetConfigurationsIDOK() *GetConfigurationsIDOK {
 	return &GetConfigurationsIDOK{}
 }
 
-/*GetConfigurationsIDOK handles this case with default header values.
+/*
+GetConfigurationsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetConfigurationsIDDefault(code int) *GetConfigurationsIDDefault {
 	}
 }
 
-/*GetConfigurationsIDDefault handles this case with default header values.
+/*
+GetConfigurationsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_containers_id_parameters.go
+++ b/client/operations/get_containers_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetContainersIDParamsWithHTTPClient(client *http.Client) *GetContainersI
 	}
 }
 
-/*GetContainersIDParams contains all the parameters to send to the API endpoint
+/*
+GetContainersIDParams contains all the parameters to send to the API endpoint
 for the get containers ID operation typically these are written to a http.Request
 */
 type GetContainersIDParams struct {

--- a/client/operations/get_containers_id_responses.go
+++ b/client/operations/get_containers_id_responses.go
@@ -47,7 +47,8 @@ func NewGetContainersIDOK() *GetContainersIDOK {
 	return &GetContainersIDOK{}
 }
 
-/*GetContainersIDOK handles this case with default header values.
+/*
+GetContainersIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetContainersIDDefault(code int) *GetContainersIDDefault {
 	}
 }
 
-/*GetContainersIDDefault handles this case with default header values.
+/*
+GetContainersIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_database_credentials_database_credential_id_operations_parameters.go
+++ b/client/operations/get_database_credentials_database_credential_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabaseCredentialsDatabaseCredentialIDOperationsParamsWithHTTPClient
 	}
 }
 
-/*GetDatabaseCredentialsDatabaseCredentialIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabaseCredentialsDatabaseCredentialIDOperationsParams contains all the parameters to send to the API endpoint
 for the get database credentials database credential ID operations operation typically these are written to a http.Request
 */
 type GetDatabaseCredentialsDatabaseCredentialIDOperationsParams struct {

--- a/client/operations/get_database_credentials_database_credential_id_operations_responses.go
+++ b/client/operations/get_database_credentials_database_credential_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabaseCredentialsDatabaseCredentialIDOperationsOK() *GetDatabaseCre
 	return &GetDatabaseCredentialsDatabaseCredentialIDOperationsOK{}
 }
 
-/*GetDatabaseCredentialsDatabaseCredentialIDOperationsOK handles this case with default header values.
+/*
+GetDatabaseCredentialsDatabaseCredentialIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabaseCredentialsDatabaseCredentialIDOperationsDefault(code int) *G
 	}
 }
 
-/*GetDatabaseCredentialsDatabaseCredentialIDOperationsDefault handles this case with default header values.
+/*
+GetDatabaseCredentialsDatabaseCredentialIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_database_credentials_id_parameters.go
+++ b/client/operations/get_database_credentials_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabaseCredentialsIDParamsWithHTTPClient(client *http.Client) *GetDa
 	}
 }
 
-/*GetDatabaseCredentialsIDParams contains all the parameters to send to the API endpoint
+/*
+GetDatabaseCredentialsIDParams contains all the parameters to send to the API endpoint
 for the get database credentials ID operation typically these are written to a http.Request
 */
 type GetDatabaseCredentialsIDParams struct {

--- a/client/operations/get_database_credentials_id_responses.go
+++ b/client/operations/get_database_credentials_id_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabaseCredentialsIDOK() *GetDatabaseCredentialsIDOK {
 	return &GetDatabaseCredentialsIDOK{}
 }
 
-/*GetDatabaseCredentialsIDOK handles this case with default header values.
+/*
+GetDatabaseCredentialsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabaseCredentialsIDDefault(code int) *GetDatabaseCredentialsIDDefau
 	}
 }
 
-/*GetDatabaseCredentialsIDDefault handles this case with default header values.
+/*
+GetDatabaseCredentialsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_database_images_id_parameters.go
+++ b/client/operations/get_database_images_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabaseImagesIDParamsWithHTTPClient(client *http.Client) *GetDatabas
 	}
 }
 
-/*GetDatabaseImagesIDParams contains all the parameters to send to the API endpoint
+/*
+GetDatabaseImagesIDParams contains all the parameters to send to the API endpoint
 for the get database images ID operation typically these are written to a http.Request
 */
 type GetDatabaseImagesIDParams struct {

--- a/client/operations/get_database_images_id_responses.go
+++ b/client/operations/get_database_images_id_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabaseImagesIDOK() *GetDatabaseImagesIDOK {
 	return &GetDatabaseImagesIDOK{}
 }
 
-/*GetDatabaseImagesIDOK handles this case with default header values.
+/*
+GetDatabaseImagesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabaseImagesIDDefault(code int) *GetDatabaseImagesIDDefault {
 	}
 }
 
-/*GetDatabaseImagesIDDefault handles this case with default header values.
+/*
+GetDatabaseImagesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_database_images_parameters.go
+++ b/client/operations/get_database_images_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabaseImagesParamsWithHTTPClient(client *http.Client) *GetDatabaseI
 	}
 }
 
-/*GetDatabaseImagesParams contains all the parameters to send to the API endpoint
+/*
+GetDatabaseImagesParams contains all the parameters to send to the API endpoint
 for the get database images operation typically these are written to a http.Request
 */
 type GetDatabaseImagesParams struct {

--- a/client/operations/get_database_images_responses.go
+++ b/client/operations/get_database_images_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabaseImagesOK() *GetDatabaseImagesOK {
 	return &GetDatabaseImagesOK{}
 }
 
-/*GetDatabaseImagesOK handles this case with default header values.
+/*
+GetDatabaseImagesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabaseImagesDefault(code int) *GetDatabaseImagesDefault {
 	}
 }
 
-/*GetDatabaseImagesDefault handles this case with default header values.
+/*
+GetDatabaseImagesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_backups_parameters.go
+++ b/client/operations/get_databases_database_id_backups_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDBackupsParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/*GetDatabasesDatabaseIDBackupsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDBackupsParams contains all the parameters to send to the API endpoint
 for the get databases database ID backups operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDBackupsParams struct {

--- a/client/operations/get_databases_database_id_backups_responses.go
+++ b/client/operations/get_databases_database_id_backups_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDBackupsOK() *GetDatabasesDatabaseIDBackupsOK {
 	return &GetDatabasesDatabaseIDBackupsOK{}
 }
 
-/*GetDatabasesDatabaseIDBackupsOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDBackupsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDBackupsDefault(code int) *GetDatabasesDatabaseIDBa
 	}
 }
 
-/*GetDatabasesDatabaseIDBackupsDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDBackupsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_configurations_parameters.go
+++ b/client/operations/get_databases_database_id_configurations_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDConfigurationsParamsWithHTTPClient(client *http.Cl
 	}
 }
 
-/*GetDatabasesDatabaseIDConfigurationsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDConfigurationsParams contains all the parameters to send to the API endpoint
 for the get databases database ID configurations operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDConfigurationsParams struct {

--- a/client/operations/get_databases_database_id_configurations_responses.go
+++ b/client/operations/get_databases_database_id_configurations_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDConfigurationsOK() *GetDatabasesDatabaseIDConfigur
 	return &GetDatabasesDatabaseIDConfigurationsOK{}
 }
 
-/*GetDatabasesDatabaseIDConfigurationsOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDConfigurationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDConfigurationsDefault(code int) *GetDatabasesDatab
 	}
 }
 
-/*GetDatabasesDatabaseIDConfigurationsDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDConfigurationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_database_credentials_parameters.go
+++ b/client/operations/get_databases_database_id_database_credentials_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDDatabaseCredentialsParamsWithHTTPClient(client *ht
 	}
 }
 
-/*GetDatabasesDatabaseIDDatabaseCredentialsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDDatabaseCredentialsParams contains all the parameters to send to the API endpoint
 for the get databases database ID database credentials operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDDatabaseCredentialsParams struct {

--- a/client/operations/get_databases_database_id_database_credentials_responses.go
+++ b/client/operations/get_databases_database_id_database_credentials_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDDatabaseCredentialsOK() *GetDatabasesDatabaseIDDat
 	return &GetDatabasesDatabaseIDDatabaseCredentialsOK{}
 }
 
-/*GetDatabasesDatabaseIDDatabaseCredentialsOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDatabaseCredentialsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDDatabaseCredentialsDefault(code int) *GetDatabases
 	}
 }
 
-/*GetDatabasesDatabaseIDDatabaseCredentialsDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDatabaseCredentialsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_database_images_id_parameters.go
+++ b/client/operations/get_databases_database_id_database_images_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDDatabaseImagesIDParamsWithHTTPClient(client *http.
 	}
 }
 
-/*GetDatabasesDatabaseIDDatabaseImagesIDParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDDatabaseImagesIDParams contains all the parameters to send to the API endpoint
 for the get databases database ID database images ID operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDDatabaseImagesIDParams struct {

--- a/client/operations/get_databases_database_id_database_images_id_responses.go
+++ b/client/operations/get_databases_database_id_database_images_id_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDDatabaseImagesIDOK() *GetDatabasesDatabaseIDDataba
 	return &GetDatabasesDatabaseIDDatabaseImagesIDOK{}
 }
 
-/*GetDatabasesDatabaseIDDatabaseImagesIDOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDatabaseImagesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDDatabaseImagesIDDefault(code int) *GetDatabasesDat
 	}
 }
 
-/*GetDatabasesDatabaseIDDatabaseImagesIDDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDatabaseImagesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_dependents_parameters.go
+++ b/client/operations/get_databases_database_id_dependents_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDDependentsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetDatabasesDatabaseIDDependentsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDDependentsParams contains all the parameters to send to the API endpoint
 for the get databases database ID dependents operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDDependentsParams struct {

--- a/client/operations/get_databases_database_id_dependents_responses.go
+++ b/client/operations/get_databases_database_id_dependents_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDDependentsOK() *GetDatabasesDatabaseIDDependentsOK
 	return &GetDatabasesDatabaseIDDependentsOK{}
 }
 
-/*GetDatabasesDatabaseIDDependentsOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDependentsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDDependentsDefault(code int) *GetDatabasesDatabaseI
 	}
 }
 
-/*GetDatabasesDatabaseIDDependentsDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDDependentsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_database_id_operations_parameters.go
+++ b/client/operations/get_databases_database_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesDatabaseIDOperationsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetDatabasesDatabaseIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesDatabaseIDOperationsParams contains all the parameters to send to the API endpoint
 for the get databases database ID operations operation typically these are written to a http.Request
 */
 type GetDatabasesDatabaseIDOperationsParams struct {

--- a/client/operations/get_databases_database_id_operations_responses.go
+++ b/client/operations/get_databases_database_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesDatabaseIDOperationsOK() *GetDatabasesDatabaseIDOperationsOK
 	return &GetDatabasesDatabaseIDOperationsOK{}
 }
 
-/*GetDatabasesDatabaseIDOperationsOK handles this case with default header values.
+/*
+GetDatabasesDatabaseIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDatabaseIDOperationsDefault(code int) *GetDatabasesDatabaseI
 	}
 }
 
-/*GetDatabasesDatabaseIDOperationsDefault handles this case with default header values.
+/*
+GetDatabasesDatabaseIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_id_parameters.go
+++ b/client/operations/get_databases_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesIDParamsWithHTTPClient(client *http.Client) *GetDatabasesIDP
 	}
 }
 
-/*GetDatabasesIDParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesIDParams contains all the parameters to send to the API endpoint
 for the get databases ID operation typically these are written to a http.Request
 */
 type GetDatabasesIDParams struct {

--- a/client/operations/get_databases_id_responses.go
+++ b/client/operations/get_databases_id_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesIDOK() *GetDatabasesIDOK {
 	return &GetDatabasesIDOK{}
 }
 
-/*GetDatabasesIDOK handles this case with default header values.
+/*
+GetDatabasesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesIDDefault(code int) *GetDatabasesIDDefault {
 	}
 }
 
-/*GetDatabasesIDDefault handles this case with default header values.
+/*
+GetDatabasesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_databases_parameters.go
+++ b/client/operations/get_databases_parameters.go
@@ -57,7 +57,8 @@ func NewGetDatabasesParamsWithHTTPClient(client *http.Client) *GetDatabasesParam
 	}
 }
 
-/*GetDatabasesParams contains all the parameters to send to the API endpoint
+/*
+GetDatabasesParams contains all the parameters to send to the API endpoint
 for the get databases operation typically these are written to a http.Request
 */
 type GetDatabasesParams struct {

--- a/client/operations/get_databases_responses.go
+++ b/client/operations/get_databases_responses.go
@@ -47,7 +47,8 @@ func NewGetDatabasesOK() *GetDatabasesOK {
 	return &GetDatabasesOK{}
 }
 
-/*GetDatabasesOK handles this case with default header values.
+/*
+GetDatabasesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDatabasesDefault(code int) *GetDatabasesDefault {
 	}
 }
 
-/*GetDatabasesDefault handles this case with default header values.
+/*
+GetDatabasesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_disks_id_parameters.go
+++ b/client/operations/get_disks_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetDisksIDParamsWithHTTPClient(client *http.Client) *GetDisksIDParams {
 	}
 }
 
-/*GetDisksIDParams contains all the parameters to send to the API endpoint
+/*
+GetDisksIDParams contains all the parameters to send to the API endpoint
 for the get disks ID operation typically these are written to a http.Request
 */
 type GetDisksIDParams struct {

--- a/client/operations/get_disks_id_responses.go
+++ b/client/operations/get_disks_id_responses.go
@@ -47,7 +47,8 @@ func NewGetDisksIDOK() *GetDisksIDOK {
 	return &GetDisksIDOK{}
 }
 
-/*GetDisksIDOK handles this case with default header values.
+/*
+GetDisksIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetDisksIDDefault(code int) *GetDisksIDDefault {
 	}
 }
 
-/*GetDisksIDDefault handles this case with default header values.
+/*
+GetDisksIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_ephemeral_containers_id_parameters.go
+++ b/client/operations/get_ephemeral_containers_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetEphemeralContainersIDParamsWithHTTPClient(client *http.Client) *GetEp
 	}
 }
 
-/*GetEphemeralContainersIDParams contains all the parameters to send to the API endpoint
+/*
+GetEphemeralContainersIDParams contains all the parameters to send to the API endpoint
 for the get ephemeral containers ID operation typically these are written to a http.Request
 */
 type GetEphemeralContainersIDParams struct {

--- a/client/operations/get_ephemeral_containers_id_responses.go
+++ b/client/operations/get_ephemeral_containers_id_responses.go
@@ -47,7 +47,8 @@ func NewGetEphemeralContainersIDOK() *GetEphemeralContainersIDOK {
 	return &GetEphemeralContainersIDOK{}
 }
 
-/*GetEphemeralContainersIDOK handles this case with default header values.
+/*
+GetEphemeralContainersIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetEphemeralContainersIDDefault(code int) *GetEphemeralContainersIDDefau
 	}
 }
 
-/*GetEphemeralContainersIDDefault handles this case with default header values.
+/*
+GetEphemeralContainersIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_ephemeral_sessions_ephemeral_session_id_ephemeral_containers_parameters.go
+++ b/client/operations/get_ephemeral_sessions_ephemeral_session_id_ephemeral_containers_parameters.go
@@ -57,7 +57,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDEphemeralContainersParamsWithHTTPC
 	}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDEphemeralContainersParams contains all the parameters to send to the API endpoint
+/*
+GetEphemeralSessionsEphemeralSessionIDEphemeralContainersParams contains all the parameters to send to the API endpoint
 for the get ephemeral sessions ephemeral session ID ephemeral containers operation typically these are written to a http.Request
 */
 type GetEphemeralSessionsEphemeralSessionIDEphemeralContainersParams struct {

--- a/client/operations/get_ephemeral_sessions_ephemeral_session_id_ephemeral_containers_responses.go
+++ b/client/operations/get_ephemeral_sessions_ephemeral_session_id_ephemeral_containers_responses.go
@@ -47,7 +47,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDEphemeralContainersOK() *GetEpheme
 	return &GetEphemeralSessionsEphemeralSessionIDEphemeralContainersOK{}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDEphemeralContainersOK handles this case with default header values.
+/*
+GetEphemeralSessionsEphemeralSessionIDEphemeralContainersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDEphemeralContainersDefault(code in
 	}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDEphemeralContainersDefault handles this case with default header values.
+/*
+GetEphemeralSessionsEphemeralSessionIDEphemeralContainersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_ephemeral_sessions_ephemeral_session_id_operations_parameters.go
+++ b/client/operations/get_ephemeral_sessions_ephemeral_session_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDOperationsParamsWithHTTPClient(cli
 	}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetEphemeralSessionsEphemeralSessionIDOperationsParams contains all the parameters to send to the API endpoint
 for the get ephemeral sessions ephemeral session ID operations operation typically these are written to a http.Request
 */
 type GetEphemeralSessionsEphemeralSessionIDOperationsParams struct {

--- a/client/operations/get_ephemeral_sessions_ephemeral_session_id_operations_responses.go
+++ b/client/operations/get_ephemeral_sessions_ephemeral_session_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDOperationsOK() *GetEphemeralSessio
 	return &GetEphemeralSessionsEphemeralSessionIDOperationsOK{}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDOperationsOK handles this case with default header values.
+/*
+GetEphemeralSessionsEphemeralSessionIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetEphemeralSessionsEphemeralSessionIDOperationsDefault(code int) *GetEp
 	}
 }
 
-/*GetEphemeralSessionsEphemeralSessionIDOperationsDefault handles this case with default header values.
+/*
+GetEphemeralSessionsEphemeralSessionIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_ephemeral_sessions_id_parameters.go
+++ b/client/operations/get_ephemeral_sessions_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetEphemeralSessionsIDParamsWithHTTPClient(client *http.Client) *GetEphe
 	}
 }
 
-/*GetEphemeralSessionsIDParams contains all the parameters to send to the API endpoint
+/*
+GetEphemeralSessionsIDParams contains all the parameters to send to the API endpoint
 for the get ephemeral sessions ID operation typically these are written to a http.Request
 */
 type GetEphemeralSessionsIDParams struct {

--- a/client/operations/get_ephemeral_sessions_id_responses.go
+++ b/client/operations/get_ephemeral_sessions_id_responses.go
@@ -47,7 +47,8 @@ func NewGetEphemeralSessionsIDOK() *GetEphemeralSessionsIDOK {
 	return &GetEphemeralSessionsIDOK{}
 }
 
-/*GetEphemeralSessionsIDOK handles this case with default header values.
+/*
+GetEphemeralSessionsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetEphemeralSessionsIDDefault(code int) *GetEphemeralSessionsIDDefault {
 	}
 }
 
-/*GetEphemeralSessionsIDDefault handles this case with default header values.
+/*
+GetEphemeralSessionsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_images_id_parameters.go
+++ b/client/operations/get_images_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetImagesIDParamsWithHTTPClient(client *http.Client) *GetImagesIDParams 
 	}
 }
 
-/*GetImagesIDParams contains all the parameters to send to the API endpoint
+/*
+GetImagesIDParams contains all the parameters to send to the API endpoint
 for the get images ID operation typically these are written to a http.Request
 */
 type GetImagesIDParams struct {

--- a/client/operations/get_images_id_responses.go
+++ b/client/operations/get_images_id_responses.go
@@ -47,7 +47,8 @@ func NewGetImagesIDOK() *GetImagesIDOK {
 	return &GetImagesIDOK{}
 }
 
-/*GetImagesIDOK handles this case with default header values.
+/*
+GetImagesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetImagesIDDefault(code int) *GetImagesIDDefault {
 	}
 }
 
-/*GetImagesIDDefault handles this case with default header values.
+/*
+GetImagesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_images_image_id_operations_parameters.go
+++ b/client/operations/get_images_image_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetImagesImageIDOperationsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetImagesImageIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetImagesImageIDOperationsParams contains all the parameters to send to the API endpoint
 for the get images image ID operations operation typically these are written to a http.Request
 */
 type GetImagesImageIDOperationsParams struct {

--- a/client/operations/get_images_image_id_operations_responses.go
+++ b/client/operations/get_images_image_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetImagesImageIDOperationsOK() *GetImagesImageIDOperationsOK {
 	return &GetImagesImageIDOperationsOK{}
 }
 
-/*GetImagesImageIDOperationsOK handles this case with default header values.
+/*
+GetImagesImageIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetImagesImageIDOperationsDefault(code int) *GetImagesImageIDOperationsD
 	}
 }
 
-/*GetImagesImageIDOperationsDefault handles this case with default header values.
+/*
+GetImagesImageIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_intrusion_detection_reports_id_parameters.go
+++ b/client/operations/get_intrusion_detection_reports_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetIntrusionDetectionReportsIDParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*GetIntrusionDetectionReportsIDParams contains all the parameters to send to the API endpoint
+/*
+GetIntrusionDetectionReportsIDParams contains all the parameters to send to the API endpoint
 for the get intrusion detection reports ID operation typically these are written to a http.Request
 */
 type GetIntrusionDetectionReportsIDParams struct {

--- a/client/operations/get_intrusion_detection_reports_id_responses.go
+++ b/client/operations/get_intrusion_detection_reports_id_responses.go
@@ -47,7 +47,8 @@ func NewGetIntrusionDetectionReportsIDOK() *GetIntrusionDetectionReportsIDOK {
 	return &GetIntrusionDetectionReportsIDOK{}
 }
 
-/*GetIntrusionDetectionReportsIDOK handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetIntrusionDetectionReportsIDDefault(code int) *GetIntrusionDetectionRe
 	}
 }
 
-/*GetIntrusionDetectionReportsIDDefault handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_csv_parameters.go
+++ b/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_csv_parameters.go
@@ -57,7 +57,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadCsvParamsWithHTTPCl
 	}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvParams contains all the parameters to send to the API endpoint
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvParams contains all the parameters to send to the API endpoint
 for the get intrusion detection reports intrusion report ID download csv operation typically these are written to a http.Request
 */
 type GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvParams struct {

--- a/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_csv_responses.go
+++ b/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_csv_responses.go
@@ -47,7 +47,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadCsvOK() *GetIntrusi
 	return &GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvOK{}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvOK handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvOK handles this case with default header values.
 
 Presigned URL
 */
@@ -70,7 +71,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadCsvDefault(code int
 	}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvDefault handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadCsvDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_pdf_parameters.go
+++ b/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_pdf_parameters.go
@@ -57,7 +57,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadPdfParamsWithHTTPCl
 	}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfParams contains all the parameters to send to the API endpoint
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfParams contains all the parameters to send to the API endpoint
 for the get intrusion detection reports intrusion report ID download pdf operation typically these are written to a http.Request
 */
 type GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfParams struct {

--- a/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_pdf_responses.go
+++ b/client/operations/get_intrusion_detection_reports_intrusion_report_id_download_pdf_responses.go
@@ -47,7 +47,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadPdfOK() *GetIntrusi
 	return &GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfOK{}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfOK handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfOK handles this case with default header values.
 
 Presigned URL
 */
@@ -70,7 +71,8 @@ func NewGetIntrusionDetectionReportsIntrusionReportIDDownloadPdfDefault(code int
 	}
 }
 
-/*GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfDefault handles this case with default header values.
+/*
+GetIntrusionDetectionReportsIntrusionReportIDDownloadPdfDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_log_drains_id_parameters.go
+++ b/client/operations/get_log_drains_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetLogDrainsIDParamsWithHTTPClient(client *http.Client) *GetLogDrainsIDP
 	}
 }
 
-/*GetLogDrainsIDParams contains all the parameters to send to the API endpoint
+/*
+GetLogDrainsIDParams contains all the parameters to send to the API endpoint
 for the get log drains ID operation typically these are written to a http.Request
 */
 type GetLogDrainsIDParams struct {

--- a/client/operations/get_log_drains_id_responses.go
+++ b/client/operations/get_log_drains_id_responses.go
@@ -47,7 +47,8 @@ func NewGetLogDrainsIDOK() *GetLogDrainsIDOK {
 	return &GetLogDrainsIDOK{}
 }
 
-/*GetLogDrainsIDOK handles this case with default header values.
+/*
+GetLogDrainsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetLogDrainsIDDefault(code int) *GetLogDrainsIDDefault {
 	}
 }
 
-/*GetLogDrainsIDDefault handles this case with default header values.
+/*
+GetLogDrainsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_log_drains_log_drain_id_containers_parameters.go
+++ b/client/operations/get_log_drains_log_drain_id_containers_parameters.go
@@ -57,7 +57,8 @@ func NewGetLogDrainsLogDrainIDContainersParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetLogDrainsLogDrainIDContainersParams contains all the parameters to send to the API endpoint
+/*
+GetLogDrainsLogDrainIDContainersParams contains all the parameters to send to the API endpoint
 for the get log drains log drain ID containers operation typically these are written to a http.Request
 */
 type GetLogDrainsLogDrainIDContainersParams struct {

--- a/client/operations/get_log_drains_log_drain_id_containers_responses.go
+++ b/client/operations/get_log_drains_log_drain_id_containers_responses.go
@@ -47,7 +47,8 @@ func NewGetLogDrainsLogDrainIDContainersOK() *GetLogDrainsLogDrainIDContainersOK
 	return &GetLogDrainsLogDrainIDContainersOK{}
 }
 
-/*GetLogDrainsLogDrainIDContainersOK handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDContainersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetLogDrainsLogDrainIDContainersDefault(code int) *GetLogDrainsLogDrainI
 	}
 }
 
-/*GetLogDrainsLogDrainIDContainersDefault handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDContainersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_log_drains_log_drain_id_ephemeral_containers_parameters.go
+++ b/client/operations/get_log_drains_log_drain_id_ephemeral_containers_parameters.go
@@ -57,7 +57,8 @@ func NewGetLogDrainsLogDrainIDEphemeralContainersParamsWithHTTPClient(client *ht
 	}
 }
 
-/*GetLogDrainsLogDrainIDEphemeralContainersParams contains all the parameters to send to the API endpoint
+/*
+GetLogDrainsLogDrainIDEphemeralContainersParams contains all the parameters to send to the API endpoint
 for the get log drains log drain ID ephemeral containers operation typically these are written to a http.Request
 */
 type GetLogDrainsLogDrainIDEphemeralContainersParams struct {

--- a/client/operations/get_log_drains_log_drain_id_ephemeral_containers_responses.go
+++ b/client/operations/get_log_drains_log_drain_id_ephemeral_containers_responses.go
@@ -47,7 +47,8 @@ func NewGetLogDrainsLogDrainIDEphemeralContainersOK() *GetLogDrainsLogDrainIDEph
 	return &GetLogDrainsLogDrainIDEphemeralContainersOK{}
 }
 
-/*GetLogDrainsLogDrainIDEphemeralContainersOK handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDEphemeralContainersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetLogDrainsLogDrainIDEphemeralContainersDefault(code int) *GetLogDrains
 	}
 }
 
-/*GetLogDrainsLogDrainIDEphemeralContainersDefault handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDEphemeralContainersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_log_drains_log_drain_id_operations_parameters.go
+++ b/client/operations/get_log_drains_log_drain_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetLogDrainsLogDrainIDOperationsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*GetLogDrainsLogDrainIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetLogDrainsLogDrainIDOperationsParams contains all the parameters to send to the API endpoint
 for the get log drains log drain ID operations operation typically these are written to a http.Request
 */
 type GetLogDrainsLogDrainIDOperationsParams struct {

--- a/client/operations/get_log_drains_log_drain_id_operations_responses.go
+++ b/client/operations/get_log_drains_log_drain_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetLogDrainsLogDrainIDOperationsOK() *GetLogDrainsLogDrainIDOperationsOK
 	return &GetLogDrainsLogDrainIDOperationsOK{}
 }
 
-/*GetLogDrainsLogDrainIDOperationsOK handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetLogDrainsLogDrainIDOperationsDefault(code int) *GetLogDrainsLogDrainI
 	}
 }
 
-/*GetLogDrainsLogDrainIDOperationsDefault handles this case with default header values.
+/*
+GetLogDrainsLogDrainIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_metric_drains_id_parameters.go
+++ b/client/operations/get_metric_drains_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetMetricDrainsIDParamsWithHTTPClient(client *http.Client) *GetMetricDra
 	}
 }
 
-/*GetMetricDrainsIDParams contains all the parameters to send to the API endpoint
+/*
+GetMetricDrainsIDParams contains all the parameters to send to the API endpoint
 for the get metric drains ID operation typically these are written to a http.Request
 */
 type GetMetricDrainsIDParams struct {

--- a/client/operations/get_metric_drains_id_responses.go
+++ b/client/operations/get_metric_drains_id_responses.go
@@ -47,7 +47,8 @@ func NewGetMetricDrainsIDOK() *GetMetricDrainsIDOK {
 	return &GetMetricDrainsIDOK{}
 }
 
-/*GetMetricDrainsIDOK handles this case with default header values.
+/*
+GetMetricDrainsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetMetricDrainsIDDefault(code int) *GetMetricDrainsIDDefault {
 	}
 }
 
-/*GetMetricDrainsIDDefault handles this case with default header values.
+/*
+GetMetricDrainsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_metric_drains_metric_drain_id_containers_parameters.go
+++ b/client/operations/get_metric_drains_metric_drain_id_containers_parameters.go
@@ -57,7 +57,8 @@ func NewGetMetricDrainsMetricDrainIDContainersParamsWithHTTPClient(client *http.
 	}
 }
 
-/*GetMetricDrainsMetricDrainIDContainersParams contains all the parameters to send to the API endpoint
+/*
+GetMetricDrainsMetricDrainIDContainersParams contains all the parameters to send to the API endpoint
 for the get metric drains metric drain ID containers operation typically these are written to a http.Request
 */
 type GetMetricDrainsMetricDrainIDContainersParams struct {

--- a/client/operations/get_metric_drains_metric_drain_id_containers_responses.go
+++ b/client/operations/get_metric_drains_metric_drain_id_containers_responses.go
@@ -47,7 +47,8 @@ func NewGetMetricDrainsMetricDrainIDContainersOK() *GetMetricDrainsMetricDrainID
 	return &GetMetricDrainsMetricDrainIDContainersOK{}
 }
 
-/*GetMetricDrainsMetricDrainIDContainersOK handles this case with default header values.
+/*
+GetMetricDrainsMetricDrainIDContainersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetMetricDrainsMetricDrainIDContainersDefault(code int) *GetMetricDrains
 	}
 }
 
-/*GetMetricDrainsMetricDrainIDContainersDefault handles this case with default header values.
+/*
+GetMetricDrainsMetricDrainIDContainersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_metric_drains_metric_drain_id_operations_parameters.go
+++ b/client/operations/get_metric_drains_metric_drain_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetMetricDrainsMetricDrainIDOperationsParamsWithHTTPClient(client *http.
 	}
 }
 
-/*GetMetricDrainsMetricDrainIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetMetricDrainsMetricDrainIDOperationsParams contains all the parameters to send to the API endpoint
 for the get metric drains metric drain ID operations operation typically these are written to a http.Request
 */
 type GetMetricDrainsMetricDrainIDOperationsParams struct {

--- a/client/operations/get_metric_drains_metric_drain_id_operations_responses.go
+++ b/client/operations/get_metric_drains_metric_drain_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetMetricDrainsMetricDrainIDOperationsOK() *GetMetricDrainsMetricDrainID
 	return &GetMetricDrainsMetricDrainIDOperationsOK{}
 }
 
-/*GetMetricDrainsMetricDrainIDOperationsOK handles this case with default header values.
+/*
+GetMetricDrainsMetricDrainIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetMetricDrainsMetricDrainIDOperationsDefault(code int) *GetMetricDrains
 	}
 }
 
-/*GetMetricDrainsMetricDrainIDOperationsDefault handles this case with default header values.
+/*
+GetMetricDrainsMetricDrainIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_operations_id_parameters.go
+++ b/client/operations/get_operations_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetOperationsIDParamsWithHTTPClient(client *http.Client) *GetOperationsI
 	}
 }
 
-/*GetOperationsIDParams contains all the parameters to send to the API endpoint
+/*
+GetOperationsIDParams contains all the parameters to send to the API endpoint
 for the get operations ID operation typically these are written to a http.Request
 */
 type GetOperationsIDParams struct {

--- a/client/operations/get_operations_id_responses.go
+++ b/client/operations/get_operations_id_responses.go
@@ -47,7 +47,8 @@ func NewGetOperationsIDOK() *GetOperationsIDOK {
 	return &GetOperationsIDOK{}
 }
 
-/*GetOperationsIDOK handles this case with default header values.
+/*
+GetOperationsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetOperationsIDDefault(code int) *GetOperationsIDDefault {
 	}
 }
 
-/*GetOperationsIDDefault handles this case with default header values.
+/*
+GetOperationsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_operations_operation_id_ephemeral_sessions_parameters.go
+++ b/client/operations/get_operations_operation_id_ephemeral_sessions_parameters.go
@@ -57,7 +57,8 @@ func NewGetOperationsOperationIDEphemeralSessionsParamsWithHTTPClient(client *ht
 	}
 }
 
-/*GetOperationsOperationIDEphemeralSessionsParams contains all the parameters to send to the API endpoint
+/*
+GetOperationsOperationIDEphemeralSessionsParams contains all the parameters to send to the API endpoint
 for the get operations operation ID ephemeral sessions operation typically these are written to a http.Request
 */
 type GetOperationsOperationIDEphemeralSessionsParams struct {

--- a/client/operations/get_operations_operation_id_ephemeral_sessions_responses.go
+++ b/client/operations/get_operations_operation_id_ephemeral_sessions_responses.go
@@ -47,7 +47,8 @@ func NewGetOperationsOperationIDEphemeralSessionsOK() *GetOperationsOperationIDE
 	return &GetOperationsOperationIDEphemeralSessionsOK{}
 }
 
-/*GetOperationsOperationIDEphemeralSessionsOK handles this case with default header values.
+/*
+GetOperationsOperationIDEphemeralSessionsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetOperationsOperationIDEphemeralSessionsDefault(code int) *GetOperation
 	}
 }
 
-/*GetOperationsOperationIDEphemeralSessionsDefault handles this case with default header values.
+/*
+GetOperationsOperationIDEphemeralSessionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_operations_operation_id_ssh_portal_connections_parameters.go
+++ b/client/operations/get_operations_operation_id_ssh_portal_connections_parameters.go
@@ -57,7 +57,8 @@ func NewGetOperationsOperationIDSSHPortalConnectionsParamsWithHTTPClient(client 
 	}
 }
 
-/*GetOperationsOperationIDSSHPortalConnectionsParams contains all the parameters to send to the API endpoint
+/*
+GetOperationsOperationIDSSHPortalConnectionsParams contains all the parameters to send to the API endpoint
 for the get operations operation ID SSH portal connections operation typically these are written to a http.Request
 */
 type GetOperationsOperationIDSSHPortalConnectionsParams struct {

--- a/client/operations/get_operations_operation_id_ssh_portal_connections_responses.go
+++ b/client/operations/get_operations_operation_id_ssh_portal_connections_responses.go
@@ -47,7 +47,8 @@ func NewGetOperationsOperationIDSSHPortalConnectionsOK() *GetOperationsOperation
 	return &GetOperationsOperationIDSSHPortalConnectionsOK{}
 }
 
-/*GetOperationsOperationIDSSHPortalConnectionsOK handles this case with default header values.
+/*
+GetOperationsOperationIDSSHPortalConnectionsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetOperationsOperationIDSSHPortalConnectionsDefault(code int) *GetOperat
 	}
 }
 
-/*GetOperationsOperationIDSSHPortalConnectionsDefault handles this case with default header values.
+/*
+GetOperationsOperationIDSSHPortalConnectionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_parameters.go
+++ b/client/operations/get_parameters.go
@@ -56,7 +56,8 @@ func NewGetParamsWithHTTPClient(client *http.Client) *GetParams {
 	}
 }
 
-/*GetParams contains all the parameters to send to the API endpoint
+/*
+GetParams contains all the parameters to send to the API endpoint
 for the get operation typically these are written to a http.Request
 */
 type GetParams struct {

--- a/client/operations/get_permissions_id_parameters.go
+++ b/client/operations/get_permissions_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetPermissionsIDParamsWithHTTPClient(client *http.Client) *GetPermission
 	}
 }
 
-/*GetPermissionsIDParams contains all the parameters to send to the API endpoint
+/*
+GetPermissionsIDParams contains all the parameters to send to the API endpoint
 for the get permissions ID operation typically these are written to a http.Request
 */
 type GetPermissionsIDParams struct {

--- a/client/operations/get_permissions_id_responses.go
+++ b/client/operations/get_permissions_id_responses.go
@@ -47,7 +47,8 @@ func NewGetPermissionsIDOK() *GetPermissionsIDOK {
 	return &GetPermissionsIDOK{}
 }
 
-/*GetPermissionsIDOK handles this case with default header values.
+/*
+GetPermissionsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetPermissionsIDDefault(code int) *GetPermissionsIDDefault {
 	}
 }
 
-/*GetPermissionsIDDefault handles this case with default header values.
+/*
+GetPermissionsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_permissions_parameters.go
+++ b/client/operations/get_permissions_parameters.go
@@ -57,7 +57,8 @@ func NewGetPermissionsParamsWithHTTPClient(client *http.Client) *GetPermissionsP
 	}
 }
 
-/*GetPermissionsParams contains all the parameters to send to the API endpoint
+/*
+GetPermissionsParams contains all the parameters to send to the API endpoint
 for the get permissions operation typically these are written to a http.Request
 */
 type GetPermissionsParams struct {

--- a/client/operations/get_permissions_responses.go
+++ b/client/operations/get_permissions_responses.go
@@ -47,7 +47,8 @@ func NewGetPermissionsOK() *GetPermissionsOK {
 	return &GetPermissionsOK{}
 }
 
-/*GetPermissionsOK handles this case with default header values.
+/*
+GetPermissionsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetPermissionsDefault(code int) *GetPermissionsDefault {
 	}
 }
 
-/*GetPermissionsDefault handles this case with default header values.
+/*
+GetPermissionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_releases_id_parameters.go
+++ b/client/operations/get_releases_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetReleasesIDParamsWithHTTPClient(client *http.Client) *GetReleasesIDPar
 	}
 }
 
-/*GetReleasesIDParams contains all the parameters to send to the API endpoint
+/*
+GetReleasesIDParams contains all the parameters to send to the API endpoint
 for the get releases ID operation typically these are written to a http.Request
 */
 type GetReleasesIDParams struct {

--- a/client/operations/get_releases_id_responses.go
+++ b/client/operations/get_releases_id_responses.go
@@ -47,7 +47,8 @@ func NewGetReleasesIDOK() *GetReleasesIDOK {
 	return &GetReleasesIDOK{}
 }
 
-/*GetReleasesIDOK handles this case with default header values.
+/*
+GetReleasesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetReleasesIDDefault(code int) *GetReleasesIDDefault {
 	}
 }
 
-/*GetReleasesIDDefault handles this case with default header values.
+/*
+GetReleasesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_releases_release_id_containers_parameters.go
+++ b/client/operations/get_releases_release_id_containers_parameters.go
@@ -57,7 +57,8 @@ func NewGetReleasesReleaseIDContainersParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*GetReleasesReleaseIDContainersParams contains all the parameters to send to the API endpoint
+/*
+GetReleasesReleaseIDContainersParams contains all the parameters to send to the API endpoint
 for the get releases release ID containers operation typically these are written to a http.Request
 */
 type GetReleasesReleaseIDContainersParams struct {

--- a/client/operations/get_releases_release_id_containers_responses.go
+++ b/client/operations/get_releases_release_id_containers_responses.go
@@ -47,7 +47,8 @@ func NewGetReleasesReleaseIDContainersOK() *GetReleasesReleaseIDContainersOK {
 	return &GetReleasesReleaseIDContainersOK{}
 }
 
-/*GetReleasesReleaseIDContainersOK handles this case with default header values.
+/*
+GetReleasesReleaseIDContainersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetReleasesReleaseIDContainersDefault(code int) *GetReleasesReleaseIDCon
 	}
 }
 
-/*GetReleasesReleaseIDContainersDefault handles this case with default header values.
+/*
+GetReleasesReleaseIDContainersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_responses.go
+++ b/client/operations/get_responses.go
@@ -41,7 +41,8 @@ func NewGetOK() *GetOK {
 	return &GetOK{}
 }
 
-/*GetOK handles this case with default header values.
+/*
+GetOK handles this case with default header values.
 
 successful
 */

--- a/client/operations/get_services_id_parameters.go
+++ b/client/operations/get_services_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetServicesIDParamsWithHTTPClient(client *http.Client) *GetServicesIDPar
 	}
 }
 
-/*GetServicesIDParams contains all the parameters to send to the API endpoint
+/*
+GetServicesIDParams contains all the parameters to send to the API endpoint
 for the get services ID operation typically these are written to a http.Request
 */
 type GetServicesIDParams struct {

--- a/client/operations/get_services_id_responses.go
+++ b/client/operations/get_services_id_responses.go
@@ -47,7 +47,8 @@ func NewGetServicesIDOK() *GetServicesIDOK {
 	return &GetServicesIDOK{}
 }
 
-/*GetServicesIDOK handles this case with default header values.
+/*
+GetServicesIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetServicesIDDefault(code int) *GetServicesIDDefault {
 	}
 }
 
-/*GetServicesIDDefault handles this case with default header values.
+/*
+GetServicesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_services_service_id_operations_parameters.go
+++ b/client/operations/get_services_service_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetServicesServiceIDOperationsParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*GetServicesServiceIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetServicesServiceIDOperationsParams contains all the parameters to send to the API endpoint
 for the get services service ID operations operation typically these are written to a http.Request
 */
 type GetServicesServiceIDOperationsParams struct {

--- a/client/operations/get_services_service_id_operations_responses.go
+++ b/client/operations/get_services_service_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetServicesServiceIDOperationsOK() *GetServicesServiceIDOperationsOK {
 	return &GetServicesServiceIDOperationsOK{}
 }
 
-/*GetServicesServiceIDOperationsOK handles this case with default header values.
+/*
+GetServicesServiceIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetServicesServiceIDOperationsDefault(code int) *GetServicesServiceIDOpe
 	}
 }
 
-/*GetServicesServiceIDOperationsDefault handles this case with default header values.
+/*
+GetServicesServiceIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_services_service_id_releases_parameters.go
+++ b/client/operations/get_services_service_id_releases_parameters.go
@@ -57,7 +57,8 @@ func NewGetServicesServiceIDReleasesParamsWithHTTPClient(client *http.Client) *G
 	}
 }
 
-/*GetServicesServiceIDReleasesParams contains all the parameters to send to the API endpoint
+/*
+GetServicesServiceIDReleasesParams contains all the parameters to send to the API endpoint
 for the get services service ID releases operation typically these are written to a http.Request
 */
 type GetServicesServiceIDReleasesParams struct {

--- a/client/operations/get_services_service_id_releases_responses.go
+++ b/client/operations/get_services_service_id_releases_responses.go
@@ -47,7 +47,8 @@ func NewGetServicesServiceIDReleasesOK() *GetServicesServiceIDReleasesOK {
 	return &GetServicesServiceIDReleasesOK{}
 }
 
-/*GetServicesServiceIDReleasesOK handles this case with default header values.
+/*
+GetServicesServiceIDReleasesOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetServicesServiceIDReleasesDefault(code int) *GetServicesServiceIDRelea
 	}
 }
 
-/*GetServicesServiceIDReleasesDefault handles this case with default header values.
+/*
+GetServicesServiceIDReleasesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_services_service_id_vhosts_parameters.go
+++ b/client/operations/get_services_service_id_vhosts_parameters.go
@@ -57,7 +57,8 @@ func NewGetServicesServiceIDVhostsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetServicesServiceIDVhostsParams contains all the parameters to send to the API endpoint
+/*
+GetServicesServiceIDVhostsParams contains all the parameters to send to the API endpoint
 for the get services service ID vhosts operation typically these are written to a http.Request
 */
 type GetServicesServiceIDVhostsParams struct {

--- a/client/operations/get_services_service_id_vhosts_responses.go
+++ b/client/operations/get_services_service_id_vhosts_responses.go
@@ -47,7 +47,8 @@ func NewGetServicesServiceIDVhostsOK() *GetServicesServiceIDVhostsOK {
 	return &GetServicesServiceIDVhostsOK{}
 }
 
-/*GetServicesServiceIDVhostsOK handles this case with default header values.
+/*
+GetServicesServiceIDVhostsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetServicesServiceIDVhostsDefault(code int) *GetServicesServiceIDVhostsD
 	}
 }
 
-/*GetServicesServiceIDVhostsDefault handles this case with default header values.
+/*
+GetServicesServiceIDVhostsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_ssh_portal_connections_id_parameters.go
+++ b/client/operations/get_ssh_portal_connections_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetSSHPortalConnectionsIDParamsWithHTTPClient(client *http.Client) *GetS
 	}
 }
 
-/*GetSSHPortalConnectionsIDParams contains all the parameters to send to the API endpoint
+/*
+GetSSHPortalConnectionsIDParams contains all the parameters to send to the API endpoint
 for the get SSH portal connections ID operation typically these are written to a http.Request
 */
 type GetSSHPortalConnectionsIDParams struct {

--- a/client/operations/get_ssh_portal_connections_id_responses.go
+++ b/client/operations/get_ssh_portal_connections_id_responses.go
@@ -47,7 +47,8 @@ func NewGetSSHPortalConnectionsIDOK() *GetSSHPortalConnectionsIDOK {
 	return &GetSSHPortalConnectionsIDOK{}
 }
 
-/*GetSSHPortalConnectionsIDOK handles this case with default header values.
+/*
+GetSSHPortalConnectionsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetSSHPortalConnectionsIDDefault(code int) *GetSSHPortalConnectionsIDDef
 	}
 }
 
-/*GetSSHPortalConnectionsIDDefault handles this case with default header values.
+/*
+GetSSHPortalConnectionsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_id_parameters.go
+++ b/client/operations/get_stacks_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksIDParamsWithHTTPClient(client *http.Client) *GetStacksIDParams 
 	}
 }
 
-/*GetStacksIDParams contains all the parameters to send to the API endpoint
+/*
+GetStacksIDParams contains all the parameters to send to the API endpoint
 for the get stacks ID operation typically these are written to a http.Request
 */
 type GetStacksIDParams struct {

--- a/client/operations/get_stacks_id_responses.go
+++ b/client/operations/get_stacks_id_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksIDOK() *GetStacksIDOK {
 	return &GetStacksIDOK{}
 }
 
-/*GetStacksIDOK handles this case with default header values.
+/*
+GetStacksIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksIDDefault(code int) *GetStacksIDDefault {
 	}
 }
 
-/*GetStacksIDDefault handles this case with default header values.
+/*
+GetStacksIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_parameters.go
+++ b/client/operations/get_stacks_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksParamsWithHTTPClient(client *http.Client) *GetStacksParams {
 	}
 }
 
-/*GetStacksParams contains all the parameters to send to the API endpoint
+/*
+GetStacksParams contains all the parameters to send to the API endpoint
 for the get stacks operation typically these are written to a http.Request
 */
 type GetStacksParams struct {

--- a/client/operations/get_stacks_responses.go
+++ b/client/operations/get_stacks_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksOK() *GetStacksOK {
 	return &GetStacksOK{}
 }
 
-/*GetStacksOK handles this case with default header values.
+/*
+GetStacksOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksDefault(code int) *GetStacksDefault {
 	}
 }
 
-/*GetStacksDefault handles this case with default header values.
+/*
+GetStacksDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_stack_id_accounts_parameters.go
+++ b/client/operations/get_stacks_stack_id_accounts_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksStackIDAccountsParamsWithHTTPClient(client *http.Client) *GetSt
 	}
 }
 
-/*GetStacksStackIDAccountsParams contains all the parameters to send to the API endpoint
+/*
+GetStacksStackIDAccountsParams contains all the parameters to send to the API endpoint
 for the get stacks stack ID accounts operation typically these are written to a http.Request
 */
 type GetStacksStackIDAccountsParams struct {

--- a/client/operations/get_stacks_stack_id_accounts_responses.go
+++ b/client/operations/get_stacks_stack_id_accounts_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksStackIDAccountsOK() *GetStacksStackIDAccountsOK {
 	return &GetStacksStackIDAccountsOK{}
 }
 
-/*GetStacksStackIDAccountsOK handles this case with default header values.
+/*
+GetStacksStackIDAccountsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksStackIDAccountsDefault(code int) *GetStacksStackIDAccountsDefau
 	}
 }
 
-/*GetStacksStackIDAccountsDefault handles this case with default header values.
+/*
+GetStacksStackIDAccountsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_stack_id_intrusion_detection_reports_parameters.go
+++ b/client/operations/get_stacks_stack_id_intrusion_detection_reports_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksStackIDIntrusionDetectionReportsParamsWithHTTPClient(client *ht
 	}
 }
 
-/*GetStacksStackIDIntrusionDetectionReportsParams contains all the parameters to send to the API endpoint
+/*
+GetStacksStackIDIntrusionDetectionReportsParams contains all the parameters to send to the API endpoint
 for the get stacks stack ID intrusion detection reports operation typically these are written to a http.Request
 */
 type GetStacksStackIDIntrusionDetectionReportsParams struct {

--- a/client/operations/get_stacks_stack_id_intrusion_detection_reports_responses.go
+++ b/client/operations/get_stacks_stack_id_intrusion_detection_reports_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksStackIDIntrusionDetectionReportsOK() *GetStacksStackIDIntrusion
 	return &GetStacksStackIDIntrusionDetectionReportsOK{}
 }
 
-/*GetStacksStackIDIntrusionDetectionReportsOK handles this case with default header values.
+/*
+GetStacksStackIDIntrusionDetectionReportsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksStackIDIntrusionDetectionReportsDefault(code int) *GetStacksSta
 	}
 }
 
-/*GetStacksStackIDIntrusionDetectionReportsDefault handles this case with default header values.
+/*
+GetStacksStackIDIntrusionDetectionReportsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_stack_id_vpc_peers_parameters.go
+++ b/client/operations/get_stacks_stack_id_vpc_peers_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksStackIDVpcPeersParamsWithHTTPClient(client *http.Client) *GetSt
 	}
 }
 
-/*GetStacksStackIDVpcPeersParams contains all the parameters to send to the API endpoint
+/*
+GetStacksStackIDVpcPeersParams contains all the parameters to send to the API endpoint
 for the get stacks stack ID vpc peers operation typically these are written to a http.Request
 */
 type GetStacksStackIDVpcPeersParams struct {

--- a/client/operations/get_stacks_stack_id_vpc_peers_responses.go
+++ b/client/operations/get_stacks_stack_id_vpc_peers_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksStackIDVpcPeersOK() *GetStacksStackIDVpcPeersOK {
 	return &GetStacksStackIDVpcPeersOK{}
 }
 
-/*GetStacksStackIDVpcPeersOK handles this case with default header values.
+/*
+GetStacksStackIDVpcPeersOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksStackIDVpcPeersDefault(code int) *GetStacksStackIDVpcPeersDefau
 	}
 }
 
-/*GetStacksStackIDVpcPeersDefault handles this case with default header values.
+/*
+GetStacksStackIDVpcPeersDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_stacks_stack_id_vpn_tunnels_parameters.go
+++ b/client/operations/get_stacks_stack_id_vpn_tunnels_parameters.go
@@ -57,7 +57,8 @@ func NewGetStacksStackIDVpnTunnelsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetStacksStackIDVpnTunnelsParams contains all the parameters to send to the API endpoint
+/*
+GetStacksStackIDVpnTunnelsParams contains all the parameters to send to the API endpoint
 for the get stacks stack ID vpn tunnels operation typically these are written to a http.Request
 */
 type GetStacksStackIDVpnTunnelsParams struct {

--- a/client/operations/get_stacks_stack_id_vpn_tunnels_responses.go
+++ b/client/operations/get_stacks_stack_id_vpn_tunnels_responses.go
@@ -47,7 +47,8 @@ func NewGetStacksStackIDVpnTunnelsOK() *GetStacksStackIDVpnTunnelsOK {
 	return &GetStacksStackIDVpnTunnelsOK{}
 }
 
-/*GetStacksStackIDVpnTunnelsOK handles this case with default header values.
+/*
+GetStacksStackIDVpnTunnelsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetStacksStackIDVpnTunnelsDefault(code int) *GetStacksStackIDVpnTunnelsD
 	}
 }
 
-/*GetStacksStackIDVpnTunnelsDefault handles this case with default header values.
+/*
+GetStacksStackIDVpnTunnelsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_vhosts_id_parameters.go
+++ b/client/operations/get_vhosts_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetVhostsIDParamsWithHTTPClient(client *http.Client) *GetVhostsIDParams 
 	}
 }
 
-/*GetVhostsIDParams contains all the parameters to send to the API endpoint
+/*
+GetVhostsIDParams contains all the parameters to send to the API endpoint
 for the get vhosts ID operation typically these are written to a http.Request
 */
 type GetVhostsIDParams struct {

--- a/client/operations/get_vhosts_id_responses.go
+++ b/client/operations/get_vhosts_id_responses.go
@@ -47,7 +47,8 @@ func NewGetVhostsIDOK() *GetVhostsIDOK {
 	return &GetVhostsIDOK{}
 }
 
-/*GetVhostsIDOK handles this case with default header values.
+/*
+GetVhostsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetVhostsIDDefault(code int) *GetVhostsIDDefault {
 	}
 }
 
-/*GetVhostsIDDefault handles this case with default header values.
+/*
+GetVhostsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_vhosts_vhost_id_operations_parameters.go
+++ b/client/operations/get_vhosts_vhost_id_operations_parameters.go
@@ -57,7 +57,8 @@ func NewGetVhostsVhostIDOperationsParamsWithHTTPClient(client *http.Client) *Get
 	}
 }
 
-/*GetVhostsVhostIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+GetVhostsVhostIDOperationsParams contains all the parameters to send to the API endpoint
 for the get vhosts vhost ID operations operation typically these are written to a http.Request
 */
 type GetVhostsVhostIDOperationsParams struct {

--- a/client/operations/get_vhosts_vhost_id_operations_responses.go
+++ b/client/operations/get_vhosts_vhost_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewGetVhostsVhostIDOperationsOK() *GetVhostsVhostIDOperationsOK {
 	return &GetVhostsVhostIDOperationsOK{}
 }
 
-/*GetVhostsVhostIDOperationsOK handles this case with default header values.
+/*
+GetVhostsVhostIDOperationsOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetVhostsVhostIDOperationsDefault(code int) *GetVhostsVhostIDOperationsD
 	}
 }
 
-/*GetVhostsVhostIDOperationsDefault handles this case with default header values.
+/*
+GetVhostsVhostIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_vpc_peers_id_parameters.go
+++ b/client/operations/get_vpc_peers_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetVpcPeersIDParamsWithHTTPClient(client *http.Client) *GetVpcPeersIDPar
 	}
 }
 
-/*GetVpcPeersIDParams contains all the parameters to send to the API endpoint
+/*
+GetVpcPeersIDParams contains all the parameters to send to the API endpoint
 for the get vpc peers ID operation typically these are written to a http.Request
 */
 type GetVpcPeersIDParams struct {

--- a/client/operations/get_vpc_peers_id_responses.go
+++ b/client/operations/get_vpc_peers_id_responses.go
@@ -47,7 +47,8 @@ func NewGetVpcPeersIDOK() *GetVpcPeersIDOK {
 	return &GetVpcPeersIDOK{}
 }
 
-/*GetVpcPeersIDOK handles this case with default header values.
+/*
+GetVpcPeersIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetVpcPeersIDDefault(code int) *GetVpcPeersIDDefault {
 	}
 }
 
-/*GetVpcPeersIDDefault handles this case with default header values.
+/*
+GetVpcPeersIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/get_vpn_tunnels_id_parameters.go
+++ b/client/operations/get_vpn_tunnels_id_parameters.go
@@ -57,7 +57,8 @@ func NewGetVpnTunnelsIDParamsWithHTTPClient(client *http.Client) *GetVpnTunnelsI
 	}
 }
 
-/*GetVpnTunnelsIDParams contains all the parameters to send to the API endpoint
+/*
+GetVpnTunnelsIDParams contains all the parameters to send to the API endpoint
 for the get vpn tunnels ID operation typically these are written to a http.Request
 */
 type GetVpnTunnelsIDParams struct {

--- a/client/operations/get_vpn_tunnels_id_responses.go
+++ b/client/operations/get_vpn_tunnels_id_responses.go
@@ -47,7 +47,8 @@ func NewGetVpnTunnelsIDOK() *GetVpnTunnelsIDOK {
 	return &GetVpnTunnelsIDOK{}
 }
 
-/*GetVpnTunnelsIDOK handles this case with default header values.
+/*
+GetVpnTunnelsIDOK handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewGetVpnTunnelsIDDefault(code int) *GetVpnTunnelsIDDefault {
 	}
 }
 
-/*GetVpnTunnelsIDDefault handles this case with default header values.
+/*
+GetVpnTunnelsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_accounts_id_parameters.go
+++ b/client/operations/patch_accounts_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchAccountsIDParamsWithHTTPClient(client *http.Client) *PatchAccountsI
 	}
 }
 
-/*PatchAccountsIDParams contains all the parameters to send to the API endpoint
+/*
+PatchAccountsIDParams contains all the parameters to send to the API endpoint
 for the patch accounts ID operation typically these are written to a http.Request
 */
 type PatchAccountsIDParams struct {

--- a/client/operations/patch_accounts_id_responses.go
+++ b/client/operations/patch_accounts_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchAccountsIDOK() *PatchAccountsIDOK {
 	return &PatchAccountsIDOK{}
 }
 
-/*PatchAccountsIDOK handles this case with default header values.
+/*
+PatchAccountsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchAccountsIDDefault(code int) *PatchAccountsIDDefault {
 	}
 }
 
-/*PatchAccountsIDDefault handles this case with default header values.
+/*
+PatchAccountsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_apps_id_parameters.go
+++ b/client/operations/patch_apps_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchAppsIDParamsWithHTTPClient(client *http.Client) *PatchAppsIDParams 
 	}
 }
 
-/*PatchAppsIDParams contains all the parameters to send to the API endpoint
+/*
+PatchAppsIDParams contains all the parameters to send to the API endpoint
 for the patch apps ID operation typically these are written to a http.Request
 */
 type PatchAppsIDParams struct {

--- a/client/operations/patch_apps_id_responses.go
+++ b/client/operations/patch_apps_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchAppsIDOK() *PatchAppsIDOK {
 	return &PatchAppsIDOK{}
 }
 
-/*PatchAppsIDOK handles this case with default header values.
+/*
+PatchAppsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchAppsIDDefault(code int) *PatchAppsIDDefault {
 	}
 }
 
-/*PatchAppsIDDefault handles this case with default header values.
+/*
+PatchAppsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_certificates_id_parameters.go
+++ b/client/operations/patch_certificates_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchCertificatesIDParamsWithHTTPClient(client *http.Client) *PatchCerti
 	}
 }
 
-/*PatchCertificatesIDParams contains all the parameters to send to the API endpoint
+/*
+PatchCertificatesIDParams contains all the parameters to send to the API endpoint
 for the patch certificates ID operation typically these are written to a http.Request
 */
 type PatchCertificatesIDParams struct {

--- a/client/operations/patch_certificates_id_responses.go
+++ b/client/operations/patch_certificates_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchCertificatesIDOK() *PatchCertificatesIDOK {
 	return &PatchCertificatesIDOK{}
 }
 
-/*PatchCertificatesIDOK handles this case with default header values.
+/*
+PatchCertificatesIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchCertificatesIDDefault(code int) *PatchCertificatesIDDefault {
 	}
 }
 
-/*PatchCertificatesIDDefault handles this case with default header values.
+/*
+PatchCertificatesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_databases_id_parameters.go
+++ b/client/operations/patch_databases_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchDatabasesIDParamsWithHTTPClient(client *http.Client) *PatchDatabase
 	}
 }
 
-/*PatchDatabasesIDParams contains all the parameters to send to the API endpoint
+/*
+PatchDatabasesIDParams contains all the parameters to send to the API endpoint
 for the patch databases ID operation typically these are written to a http.Request
 */
 type PatchDatabasesIDParams struct {

--- a/client/operations/patch_databases_id_responses.go
+++ b/client/operations/patch_databases_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchDatabasesIDOK() *PatchDatabasesIDOK {
 	return &PatchDatabasesIDOK{}
 }
 
-/*PatchDatabasesIDOK handles this case with default header values.
+/*
+PatchDatabasesIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchDatabasesIDDefault(code int) *PatchDatabasesIDDefault {
 	}
 }
 
-/*PatchDatabasesIDDefault handles this case with default header values.
+/*
+PatchDatabasesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_log_drains_id_parameters.go
+++ b/client/operations/patch_log_drains_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchLogDrainsIDParamsWithHTTPClient(client *http.Client) *PatchLogDrain
 	}
 }
 
-/*PatchLogDrainsIDParams contains all the parameters to send to the API endpoint
+/*
+PatchLogDrainsIDParams contains all the parameters to send to the API endpoint
 for the patch log drains ID operation typically these are written to a http.Request
 */
 type PatchLogDrainsIDParams struct {

--- a/client/operations/patch_log_drains_id_responses.go
+++ b/client/operations/patch_log_drains_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchLogDrainsIDOK() *PatchLogDrainsIDOK {
 	return &PatchLogDrainsIDOK{}
 }
 
-/*PatchLogDrainsIDOK handles this case with default header values.
+/*
+PatchLogDrainsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchLogDrainsIDDefault(code int) *PatchLogDrainsIDDefault {
 	}
 }
 
-/*PatchLogDrainsIDDefault handles this case with default header values.
+/*
+PatchLogDrainsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_operations_id_parameters.go
+++ b/client/operations/patch_operations_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchOperationsIDParamsWithHTTPClient(client *http.Client) *PatchOperati
 	}
 }
 
-/*PatchOperationsIDParams contains all the parameters to send to the API endpoint
+/*
+PatchOperationsIDParams contains all the parameters to send to the API endpoint
 for the patch operations ID operation typically these are written to a http.Request
 */
 type PatchOperationsIDParams struct {

--- a/client/operations/patch_operations_id_responses.go
+++ b/client/operations/patch_operations_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchOperationsIDOK() *PatchOperationsIDOK {
 	return &PatchOperationsIDOK{}
 }
 
-/*PatchOperationsIDOK handles this case with default header values.
+/*
+PatchOperationsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchOperationsIDDefault(code int) *PatchOperationsIDDefault {
 	}
 }
 
-/*PatchOperationsIDDefault handles this case with default header values.
+/*
+PatchOperationsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/patch_vhosts_id_parameters.go
+++ b/client/operations/patch_vhosts_id_parameters.go
@@ -59,7 +59,8 @@ func NewPatchVhostsIDParamsWithHTTPClient(client *http.Client) *PatchVhostsIDPar
 	}
 }
 
-/*PatchVhostsIDParams contains all the parameters to send to the API endpoint
+/*
+PatchVhostsIDParams contains all the parameters to send to the API endpoint
 for the patch vhosts ID operation typically these are written to a http.Request
 */
 type PatchVhostsIDParams struct {

--- a/client/operations/patch_vhosts_id_responses.go
+++ b/client/operations/patch_vhosts_id_responses.go
@@ -47,7 +47,8 @@ func NewPatchVhostsIDOK() *PatchVhostsIDOK {
 	return &PatchVhostsIDOK{}
 }
 
-/*PatchVhostsIDOK handles this case with default header values.
+/*
+PatchVhostsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPatchVhostsIDDefault(code int) *PatchVhostsIDDefault {
 	}
 }
 
-/*PatchVhostsIDDefault handles this case with default header values.
+/*
+PatchVhostsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_apps_parameters.go
+++ b/client/operations/post_accounts_account_id_apps_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDAppsParamsWithHTTPClient(client *http.Client) *Post
 	}
 }
 
-/*PostAccountsAccountIDAppsParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDAppsParams contains all the parameters to send to the API endpoint
 for the post accounts account ID apps operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDAppsParams struct {

--- a/client/operations/post_accounts_account_id_apps_responses.go
+++ b/client/operations/post_accounts_account_id_apps_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDAppsCreated() *PostAccountsAccountIDAppsCreated {
 	return &PostAccountsAccountIDAppsCreated{}
 }
 
-/*PostAccountsAccountIDAppsCreated handles this case with default header values.
+/*
+PostAccountsAccountIDAppsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDAppsDefault(code int) *PostAccountsAccountIDAppsDef
 	}
 }
 
-/*PostAccountsAccountIDAppsDefault handles this case with default header values.
+/*
+PostAccountsAccountIDAppsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_backup_retention_policies_parameters.go
+++ b/client/operations/post_accounts_account_id_backup_retention_policies_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDBackupRetentionPoliciesParamsWithHTTPClient(client 
 	}
 }
 
-/*PostAccountsAccountIDBackupRetentionPoliciesParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDBackupRetentionPoliciesParams contains all the parameters to send to the API endpoint
 for the post accounts account ID backup retention policies operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDBackupRetentionPoliciesParams struct {

--- a/client/operations/post_accounts_account_id_backup_retention_policies_responses.go
+++ b/client/operations/post_accounts_account_id_backup_retention_policies_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDBackupRetentionPoliciesCreated() *PostAccountsAccou
 	return &PostAccountsAccountIDBackupRetentionPoliciesCreated{}
 }
 
-/*PostAccountsAccountIDBackupRetentionPoliciesCreated handles this case with default header values.
+/*
+PostAccountsAccountIDBackupRetentionPoliciesCreated handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPostAccountsAccountIDBackupRetentionPoliciesDefault(code int) *PostAccou
 	}
 }
 
-/*PostAccountsAccountIDBackupRetentionPoliciesDefault handles this case with default header values.
+/*
+PostAccountsAccountIDBackupRetentionPoliciesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_certificates_parameters.go
+++ b/client/operations/post_accounts_account_id_certificates_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDCertificatesParamsWithHTTPClient(client *http.Clien
 	}
 }
 
-/*PostAccountsAccountIDCertificatesParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDCertificatesParams contains all the parameters to send to the API endpoint
 for the post accounts account ID certificates operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDCertificatesParams struct {

--- a/client/operations/post_accounts_account_id_certificates_responses.go
+++ b/client/operations/post_accounts_account_id_certificates_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDCertificatesCreated() *PostAccountsAccountIDCertifi
 	return &PostAccountsAccountIDCertificatesCreated{}
 }
 
-/*PostAccountsAccountIDCertificatesCreated handles this case with default header values.
+/*
+PostAccountsAccountIDCertificatesCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDCertificatesDefault(code int) *PostAccountsAccountI
 	}
 }
 
-/*PostAccountsAccountIDCertificatesDefault handles this case with default header values.
+/*
+PostAccountsAccountIDCertificatesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_claims_type_parameters.go
+++ b/client/operations/post_accounts_account_id_claims_type_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDClaimsTypeParamsWithHTTPClient(client *http.Client)
 	}
 }
 
-/*PostAccountsAccountIDClaimsTypeParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDClaimsTypeParams contains all the parameters to send to the API endpoint
 for the post accounts account ID claims type operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDClaimsTypeParams struct {

--- a/client/operations/post_accounts_account_id_claims_type_responses.go
+++ b/client/operations/post_accounts_account_id_claims_type_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDClaimsTypeNoContent() *PostAccountsAccountIDClaimsT
 	return &PostAccountsAccountIDClaimsTypeNoContent{}
 }
 
-/*PostAccountsAccountIDClaimsTypeNoContent handles this case with default header values.
+/*
+PostAccountsAccountIDClaimsTypeNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPostAccountsAccountIDClaimsTypeDefault(code int) *PostAccountsAccountIDC
 	}
 }
 
-/*PostAccountsAccountIDClaimsTypeDefault handles this case with default header values.
+/*
+PostAccountsAccountIDClaimsTypeDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_databases_parameters.go
+++ b/client/operations/post_accounts_account_id_databases_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDDatabasesParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*PostAccountsAccountIDDatabasesParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDDatabasesParams contains all the parameters to send to the API endpoint
 for the post accounts account ID databases operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDDatabasesParams struct {

--- a/client/operations/post_accounts_account_id_databases_responses.go
+++ b/client/operations/post_accounts_account_id_databases_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDDatabasesCreated() *PostAccountsAccountIDDatabasesC
 	return &PostAccountsAccountIDDatabasesCreated{}
 }
 
-/*PostAccountsAccountIDDatabasesCreated handles this case with default header values.
+/*
+PostAccountsAccountIDDatabasesCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDDatabasesDefault(code int) *PostAccountsAccountIDDa
 	}
 }
 
-/*PostAccountsAccountIDDatabasesDefault handles this case with default header values.
+/*
+PostAccountsAccountIDDatabasesDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_log_drains_parameters.go
+++ b/client/operations/post_accounts_account_id_log_drains_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDLogDrainsParamsWithHTTPClient(client *http.Client) 
 	}
 }
 
-/*PostAccountsAccountIDLogDrainsParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDLogDrainsParams contains all the parameters to send to the API endpoint
 for the post accounts account ID log drains operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDLogDrainsParams struct {

--- a/client/operations/post_accounts_account_id_log_drains_responses.go
+++ b/client/operations/post_accounts_account_id_log_drains_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDLogDrainsCreated() *PostAccountsAccountIDLogDrainsC
 	return &PostAccountsAccountIDLogDrainsCreated{}
 }
 
-/*PostAccountsAccountIDLogDrainsCreated handles this case with default header values.
+/*
+PostAccountsAccountIDLogDrainsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDLogDrainsDefault(code int) *PostAccountsAccountIDLo
 	}
 }
 
-/*PostAccountsAccountIDLogDrainsDefault handles this case with default header values.
+/*
+PostAccountsAccountIDLogDrainsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_metric_drains_parameters.go
+++ b/client/operations/post_accounts_account_id_metric_drains_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDMetricDrainsParamsWithHTTPClient(client *http.Clien
 	}
 }
 
-/*PostAccountsAccountIDMetricDrainsParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDMetricDrainsParams contains all the parameters to send to the API endpoint
 for the post accounts account ID metric drains operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDMetricDrainsParams struct {

--- a/client/operations/post_accounts_account_id_metric_drains_responses.go
+++ b/client/operations/post_accounts_account_id_metric_drains_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDMetricDrainsCreated() *PostAccountsAccountIDMetricD
 	return &PostAccountsAccountIDMetricDrainsCreated{}
 }
 
-/*PostAccountsAccountIDMetricDrainsCreated handles this case with default header values.
+/*
+PostAccountsAccountIDMetricDrainsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDMetricDrainsDefault(code int) *PostAccountsAccountI
 	}
 }
 
-/*PostAccountsAccountIDMetricDrainsDefault handles this case with default header values.
+/*
+PostAccountsAccountIDMetricDrainsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_account_id_permissions_parameters.go
+++ b/client/operations/post_accounts_account_id_permissions_parameters.go
@@ -59,7 +59,8 @@ func NewPostAccountsAccountIDPermissionsParamsWithHTTPClient(client *http.Client
 	}
 }
 
-/*PostAccountsAccountIDPermissionsParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsAccountIDPermissionsParams contains all the parameters to send to the API endpoint
 for the post accounts account ID permissions operation typically these are written to a http.Request
 */
 type PostAccountsAccountIDPermissionsParams struct {

--- a/client/operations/post_accounts_account_id_permissions_responses.go
+++ b/client/operations/post_accounts_account_id_permissions_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsAccountIDPermissionsCreated() *PostAccountsAccountIDPermissi
 	return &PostAccountsAccountIDPermissionsCreated{}
 }
 
-/*PostAccountsAccountIDPermissionsCreated handles this case with default header values.
+/*
+PostAccountsAccountIDPermissionsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsAccountIDPermissionsDefault(code int) *PostAccountsAccountID
 	}
 }
 
-/*PostAccountsAccountIDPermissionsDefault handles this case with default header values.
+/*
+PostAccountsAccountIDPermissionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_accounts_parameters.go
+++ b/client/operations/post_accounts_parameters.go
@@ -58,7 +58,8 @@ func NewPostAccountsParamsWithHTTPClient(client *http.Client) *PostAccountsParam
 	}
 }
 
-/*PostAccountsParams contains all the parameters to send to the API endpoint
+/*
+PostAccountsParams contains all the parameters to send to the API endpoint
 for the post accounts operation typically these are written to a http.Request
 */
 type PostAccountsParams struct {

--- a/client/operations/post_accounts_responses.go
+++ b/client/operations/post_accounts_responses.go
@@ -47,7 +47,8 @@ func NewPostAccountsCreated() *PostAccountsCreated {
 	return &PostAccountsCreated{}
 }
 
-/*PostAccountsCreated handles this case with default header values.
+/*
+PostAccountsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAccountsDefault(code int) *PostAccountsDefault {
 	}
 }
 
-/*PostAccountsDefault handles this case with default header values.
+/*
+PostAccountsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_apps_app_id_configurations_parameters.go
+++ b/client/operations/post_apps_app_id_configurations_parameters.go
@@ -59,7 +59,8 @@ func NewPostAppsAppIDConfigurationsParamsWithHTTPClient(client *http.Client) *Po
 	}
 }
 
-/*PostAppsAppIDConfigurationsParams contains all the parameters to send to the API endpoint
+/*
+PostAppsAppIDConfigurationsParams contains all the parameters to send to the API endpoint
 for the post apps app ID configurations operation typically these are written to a http.Request
 */
 type PostAppsAppIDConfigurationsParams struct {

--- a/client/operations/post_apps_app_id_configurations_responses.go
+++ b/client/operations/post_apps_app_id_configurations_responses.go
@@ -47,7 +47,8 @@ func NewPostAppsAppIDConfigurationsCreated() *PostAppsAppIDConfigurationsCreated
 	return &PostAppsAppIDConfigurationsCreated{}
 }
 
-/*PostAppsAppIDConfigurationsCreated handles this case with default header values.
+/*
+PostAppsAppIDConfigurationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAppsAppIDConfigurationsDefault(code int) *PostAppsAppIDConfiguration
 	}
 }
 
-/*PostAppsAppIDConfigurationsDefault handles this case with default header values.
+/*
+PostAppsAppIDConfigurationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_apps_app_id_operations_parameters.go
+++ b/client/operations/post_apps_app_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostAppsAppIDOperationsParamsWithHTTPClient(client *http.Client) *PostAp
 	}
 }
 
-/*PostAppsAppIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostAppsAppIDOperationsParams contains all the parameters to send to the API endpoint
 for the post apps app ID operations operation typically these are written to a http.Request
 */
 type PostAppsAppIDOperationsParams struct {

--- a/client/operations/post_apps_app_id_operations_responses.go
+++ b/client/operations/post_apps_app_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostAppsAppIDOperationsCreated() *PostAppsAppIDOperationsCreated {
 	return &PostAppsAppIDOperationsCreated{}
 }
 
-/*PostAppsAppIDOperationsCreated handles this case with default header values.
+/*
+PostAppsAppIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostAppsAppIDOperationsDefault(code int) *PostAppsAppIDOperationsDefault
 	}
 }
 
-/*PostAppsAppIDOperationsDefault handles this case with default header values.
+/*
+PostAppsAppIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_backups_backup_id_operations_parameters.go
+++ b/client/operations/post_backups_backup_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostBackupsBackupIDOperationsParamsWithHTTPClient(client *http.Client) *
 	}
 }
 
-/*PostBackupsBackupIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostBackupsBackupIDOperationsParams contains all the parameters to send to the API endpoint
 for the post backups backup ID operations operation typically these are written to a http.Request
 */
 type PostBackupsBackupIDOperationsParams struct {

--- a/client/operations/post_backups_backup_id_operations_responses.go
+++ b/client/operations/post_backups_backup_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostBackupsBackupIDOperationsCreated() *PostBackupsBackupIDOperationsCre
 	return &PostBackupsBackupIDOperationsCreated{}
 }
 
-/*PostBackupsBackupIDOperationsCreated handles this case with default header values.
+/*
+PostBackupsBackupIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostBackupsBackupIDOperationsDefault(code int) *PostBackupsBackupIDOpera
 	}
 }
 
-/*PostBackupsBackupIDOperationsDefault handles this case with default header values.
+/*
+PostBackupsBackupIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_claims_parameters.go
+++ b/client/operations/post_claims_parameters.go
@@ -58,7 +58,8 @@ func NewPostClaimsParamsWithHTTPClient(client *http.Client) *PostClaimsParams {
 	}
 }
 
-/*PostClaimsParams contains all the parameters to send to the API endpoint
+/*
+PostClaimsParams contains all the parameters to send to the API endpoint
 for the post claims operation typically these are written to a http.Request
 */
 type PostClaimsParams struct {

--- a/client/operations/post_claims_responses.go
+++ b/client/operations/post_claims_responses.go
@@ -47,7 +47,8 @@ func NewPostClaimsNoContent() *PostClaimsNoContent {
 	return &PostClaimsNoContent{}
 }
 
-/*PostClaimsNoContent handles this case with default header values.
+/*
+PostClaimsNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPostClaimsDefault(code int) *PostClaimsDefault {
 	}
 }
 
-/*PostClaimsDefault handles this case with default header values.
+/*
+PostClaimsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_claims_type_parameters.go
+++ b/client/operations/post_claims_type_parameters.go
@@ -58,7 +58,8 @@ func NewPostClaimsTypeParamsWithHTTPClient(client *http.Client) *PostClaimsTypeP
 	}
 }
 
-/*PostClaimsTypeParams contains all the parameters to send to the API endpoint
+/*
+PostClaimsTypeParams contains all the parameters to send to the API endpoint
 for the post claims type operation typically these are written to a http.Request
 */
 type PostClaimsTypeParams struct {

--- a/client/operations/post_claims_type_responses.go
+++ b/client/operations/post_claims_type_responses.go
@@ -47,7 +47,8 @@ func NewPostClaimsTypeNoContent() *PostClaimsTypeNoContent {
 	return &PostClaimsTypeNoContent{}
 }
 
-/*PostClaimsTypeNoContent handles this case with default header values.
+/*
+PostClaimsTypeNoContent handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPostClaimsTypeDefault(code int) *PostClaimsTypeDefault {
 	}
 }
 
-/*PostClaimsTypeDefault handles this case with default header values.
+/*
+PostClaimsTypeDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_database_credentials_database_credential_id_operations_parameters.go
+++ b/client/operations/post_database_credentials_database_credential_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostDatabaseCredentialsDatabaseCredentialIDOperationsParamsWithHTTPClien
 	}
 }
 
-/*PostDatabaseCredentialsDatabaseCredentialIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostDatabaseCredentialsDatabaseCredentialIDOperationsParams contains all the parameters to send to the API endpoint
 for the post database credentials database credential ID operations operation typically these are written to a http.Request
 */
 type PostDatabaseCredentialsDatabaseCredentialIDOperationsParams struct {

--- a/client/operations/post_database_credentials_database_credential_id_operations_responses.go
+++ b/client/operations/post_database_credentials_database_credential_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostDatabaseCredentialsDatabaseCredentialIDOperationsCreated() *PostData
 	return &PostDatabaseCredentialsDatabaseCredentialIDOperationsCreated{}
 }
 
-/*PostDatabaseCredentialsDatabaseCredentialIDOperationsCreated handles this case with default header values.
+/*
+PostDatabaseCredentialsDatabaseCredentialIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostDatabaseCredentialsDatabaseCredentialIDOperationsDefault(code int) *
 	}
 }
 
-/*PostDatabaseCredentialsDatabaseCredentialIDOperationsDefault handles this case with default header values.
+/*
+PostDatabaseCredentialsDatabaseCredentialIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_databases_database_id_configurations_parameters.go
+++ b/client/operations/post_databases_database_id_configurations_parameters.go
@@ -59,7 +59,8 @@ func NewPostDatabasesDatabaseIDConfigurationsParamsWithHTTPClient(client *http.C
 	}
 }
 
-/*PostDatabasesDatabaseIDConfigurationsParams contains all the parameters to send to the API endpoint
+/*
+PostDatabasesDatabaseIDConfigurationsParams contains all the parameters to send to the API endpoint
 for the post databases database ID configurations operation typically these are written to a http.Request
 */
 type PostDatabasesDatabaseIDConfigurationsParams struct {

--- a/client/operations/post_databases_database_id_configurations_responses.go
+++ b/client/operations/post_databases_database_id_configurations_responses.go
@@ -47,7 +47,8 @@ func NewPostDatabasesDatabaseIDConfigurationsCreated() *PostDatabasesDatabaseIDC
 	return &PostDatabasesDatabaseIDConfigurationsCreated{}
 }
 
-/*PostDatabasesDatabaseIDConfigurationsCreated handles this case with default header values.
+/*
+PostDatabasesDatabaseIDConfigurationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostDatabasesDatabaseIDConfigurationsDefault(code int) *PostDatabasesDat
 	}
 }
 
-/*PostDatabasesDatabaseIDConfigurationsDefault handles this case with default header values.
+/*
+PostDatabasesDatabaseIDConfigurationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_databases_database_id_operations_parameters.go
+++ b/client/operations/post_databases_database_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostDatabasesDatabaseIDOperationsParamsWithHTTPClient(client *http.Clien
 	}
 }
 
-/*PostDatabasesDatabaseIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostDatabasesDatabaseIDOperationsParams contains all the parameters to send to the API endpoint
 for the post databases database ID operations operation typically these are written to a http.Request
 */
 type PostDatabasesDatabaseIDOperationsParams struct {

--- a/client/operations/post_databases_database_id_operations_responses.go
+++ b/client/operations/post_databases_database_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostDatabasesDatabaseIDOperationsCreated() *PostDatabasesDatabaseIDOpera
 	return &PostDatabasesDatabaseIDOperationsCreated{}
 }
 
-/*PostDatabasesDatabaseIDOperationsCreated handles this case with default header values.
+/*
+PostDatabasesDatabaseIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostDatabasesDatabaseIDOperationsDefault(code int) *PostDatabasesDatabas
 	}
 }
 
-/*PostDatabasesDatabaseIDOperationsDefault handles this case with default header values.
+/*
+PostDatabasesDatabaseIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_ephemeral_sessions_ephemeral_session_id_operations_parameters.go
+++ b/client/operations/post_ephemeral_sessions_ephemeral_session_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostEphemeralSessionsEphemeralSessionIDOperationsParamsWithHTTPClient(cl
 	}
 }
 
-/*PostEphemeralSessionsEphemeralSessionIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostEphemeralSessionsEphemeralSessionIDOperationsParams contains all the parameters to send to the API endpoint
 for the post ephemeral sessions ephemeral session ID operations operation typically these are written to a http.Request
 */
 type PostEphemeralSessionsEphemeralSessionIDOperationsParams struct {

--- a/client/operations/post_ephemeral_sessions_ephemeral_session_id_operations_responses.go
+++ b/client/operations/post_ephemeral_sessions_ephemeral_session_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostEphemeralSessionsEphemeralSessionIDOperationsCreated() *PostEphemera
 	return &PostEphemeralSessionsEphemeralSessionIDOperationsCreated{}
 }
 
-/*PostEphemeralSessionsEphemeralSessionIDOperationsCreated handles this case with default header values.
+/*
+PostEphemeralSessionsEphemeralSessionIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostEphemeralSessionsEphemeralSessionIDOperationsDefault(code int) *Post
 	}
 }
 
-/*PostEphemeralSessionsEphemeralSessionIDOperationsDefault handles this case with default header values.
+/*
+PostEphemeralSessionsEphemeralSessionIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_images_image_id_operations_parameters.go
+++ b/client/operations/post_images_image_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostImagesImageIDOperationsParamsWithHTTPClient(client *http.Client) *Po
 	}
 }
 
-/*PostImagesImageIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostImagesImageIDOperationsParams contains all the parameters to send to the API endpoint
 for the post images image ID operations operation typically these are written to a http.Request
 */
 type PostImagesImageIDOperationsParams struct {

--- a/client/operations/post_images_image_id_operations_responses.go
+++ b/client/operations/post_images_image_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostImagesImageIDOperationsCreated() *PostImagesImageIDOperationsCreated
 	return &PostImagesImageIDOperationsCreated{}
 }
 
-/*PostImagesImageIDOperationsCreated handles this case with default header values.
+/*
+PostImagesImageIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostImagesImageIDOperationsDefault(code int) *PostImagesImageIDOperation
 	}
 }
 
-/*PostImagesImageIDOperationsDefault handles this case with default header values.
+/*
+PostImagesImageIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_log_drains_log_drain_id_operations_parameters.go
+++ b/client/operations/post_log_drains_log_drain_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostLogDrainsLogDrainIDOperationsParamsWithHTTPClient(client *http.Clien
 	}
 }
 
-/*PostLogDrainsLogDrainIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostLogDrainsLogDrainIDOperationsParams contains all the parameters to send to the API endpoint
 for the post log drains log drain ID operations operation typically these are written to a http.Request
 */
 type PostLogDrainsLogDrainIDOperationsParams struct {

--- a/client/operations/post_log_drains_log_drain_id_operations_responses.go
+++ b/client/operations/post_log_drains_log_drain_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostLogDrainsLogDrainIDOperationsCreated() *PostLogDrainsLogDrainIDOpera
 	return &PostLogDrainsLogDrainIDOperationsCreated{}
 }
 
-/*PostLogDrainsLogDrainIDOperationsCreated handles this case with default header values.
+/*
+PostLogDrainsLogDrainIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostLogDrainsLogDrainIDOperationsDefault(code int) *PostLogDrainsLogDrai
 	}
 }
 
-/*PostLogDrainsLogDrainIDOperationsDefault handles this case with default header values.
+/*
+PostLogDrainsLogDrainIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_metric_drains_metric_drain_id_operations_parameters.go
+++ b/client/operations/post_metric_drains_metric_drain_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostMetricDrainsMetricDrainIDOperationsParamsWithHTTPClient(client *http
 	}
 }
 
-/*PostMetricDrainsMetricDrainIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostMetricDrainsMetricDrainIDOperationsParams contains all the parameters to send to the API endpoint
 for the post metric drains metric drain ID operations operation typically these are written to a http.Request
 */
 type PostMetricDrainsMetricDrainIDOperationsParams struct {

--- a/client/operations/post_metric_drains_metric_drain_id_operations_responses.go
+++ b/client/operations/post_metric_drains_metric_drain_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostMetricDrainsMetricDrainIDOperationsCreated() *PostMetricDrainsMetric
 	return &PostMetricDrainsMetricDrainIDOperationsCreated{}
 }
 
-/*PostMetricDrainsMetricDrainIDOperationsCreated handles this case with default header values.
+/*
+PostMetricDrainsMetricDrainIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostMetricDrainsMetricDrainIDOperationsDefault(code int) *PostMetricDrai
 	}
 }
 
-/*PostMetricDrainsMetricDrainIDOperationsDefault handles this case with default header values.
+/*
+PostMetricDrainsMetricDrainIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_operations_operation_id_ssh_portal_connections_parameters.go
+++ b/client/operations/post_operations_operation_id_ssh_portal_connections_parameters.go
@@ -59,7 +59,8 @@ func NewPostOperationsOperationIDSSHPortalConnectionsParamsWithHTTPClient(client
 	}
 }
 
-/*PostOperationsOperationIDSSHPortalConnectionsParams contains all the parameters to send to the API endpoint
+/*
+PostOperationsOperationIDSSHPortalConnectionsParams contains all the parameters to send to the API endpoint
 for the post operations operation ID SSH portal connections operation typically these are written to a http.Request
 */
 type PostOperationsOperationIDSSHPortalConnectionsParams struct {

--- a/client/operations/post_operations_operation_id_ssh_portal_connections_responses.go
+++ b/client/operations/post_operations_operation_id_ssh_portal_connections_responses.go
@@ -47,7 +47,8 @@ func NewPostOperationsOperationIDSSHPortalConnectionsCreated() *PostOperationsOp
 	return &PostOperationsOperationIDSSHPortalConnectionsCreated{}
 }
 
-/*PostOperationsOperationIDSSHPortalConnectionsCreated handles this case with default header values.
+/*
+PostOperationsOperationIDSSHPortalConnectionsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostOperationsOperationIDSSHPortalConnectionsDefault(code int) *PostOper
 	}
 }
 
-/*PostOperationsOperationIDSSHPortalConnectionsDefault handles this case with default header values.
+/*
+PostOperationsOperationIDSSHPortalConnectionsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_services_service_id_operations_parameters.go
+++ b/client/operations/post_services_service_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostServicesServiceIDOperationsParamsWithHTTPClient(client *http.Client)
 	}
 }
 
-/*PostServicesServiceIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostServicesServiceIDOperationsParams contains all the parameters to send to the API endpoint
 for the post services service ID operations operation typically these are written to a http.Request
 */
 type PostServicesServiceIDOperationsParams struct {

--- a/client/operations/post_services_service_id_operations_responses.go
+++ b/client/operations/post_services_service_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostServicesServiceIDOperationsCreated() *PostServicesServiceIDOperation
 	return &PostServicesServiceIDOperationsCreated{}
 }
 
-/*PostServicesServiceIDOperationsCreated handles this case with default header values.
+/*
+PostServicesServiceIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostServicesServiceIDOperationsDefault(code int) *PostServicesServiceIDO
 	}
 }
 
-/*PostServicesServiceIDOperationsDefault handles this case with default header values.
+/*
+PostServicesServiceIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_services_service_id_vhosts_parameters.go
+++ b/client/operations/post_services_service_id_vhosts_parameters.go
@@ -59,7 +59,8 @@ func NewPostServicesServiceIDVhostsParamsWithHTTPClient(client *http.Client) *Po
 	}
 }
 
-/*PostServicesServiceIDVhostsParams contains all the parameters to send to the API endpoint
+/*
+PostServicesServiceIDVhostsParams contains all the parameters to send to the API endpoint
 for the post services service ID vhosts operation typically these are written to a http.Request
 */
 type PostServicesServiceIDVhostsParams struct {

--- a/client/operations/post_services_service_id_vhosts_responses.go
+++ b/client/operations/post_services_service_id_vhosts_responses.go
@@ -47,7 +47,8 @@ func NewPostServicesServiceIDVhostsCreated() *PostServicesServiceIDVhostsCreated
 	return &PostServicesServiceIDVhostsCreated{}
 }
 
-/*PostServicesServiceIDVhostsCreated handles this case with default header values.
+/*
+PostServicesServiceIDVhostsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostServicesServiceIDVhostsDefault(code int) *PostServicesServiceIDVhost
 	}
 }
 
-/*PostServicesServiceIDVhostsDefault handles this case with default header values.
+/*
+PostServicesServiceIDVhostsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/post_vhosts_vhost_id_operations_parameters.go
+++ b/client/operations/post_vhosts_vhost_id_operations_parameters.go
@@ -59,7 +59,8 @@ func NewPostVhostsVhostIDOperationsParamsWithHTTPClient(client *http.Client) *Po
 	}
 }
 
-/*PostVhostsVhostIDOperationsParams contains all the parameters to send to the API endpoint
+/*
+PostVhostsVhostIDOperationsParams contains all the parameters to send to the API endpoint
 for the post vhosts vhost ID operations operation typically these are written to a http.Request
 */
 type PostVhostsVhostIDOperationsParams struct {

--- a/client/operations/post_vhosts_vhost_id_operations_responses.go
+++ b/client/operations/post_vhosts_vhost_id_operations_responses.go
@@ -47,7 +47,8 @@ func NewPostVhostsVhostIDOperationsCreated() *PostVhostsVhostIDOperationsCreated
 	return &PostVhostsVhostIDOperationsCreated{}
 }
 
-/*PostVhostsVhostIDOperationsCreated handles this case with default header values.
+/*
+PostVhostsVhostIDOperationsCreated handles this case with default header values.
 
 successful
 */
@@ -82,7 +83,8 @@ func NewPostVhostsVhostIDOperationsDefault(code int) *PostVhostsVhostIDOperation
 	}
 }
 
-/*PostVhostsVhostIDOperationsDefault handles this case with default header values.
+/*
+PostVhostsVhostIDOperationsDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_accounts_id_parameters.go
+++ b/client/operations/put_accounts_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutAccountsIDParamsWithHTTPClient(client *http.Client) *PutAccountsIDPar
 	}
 }
 
-/*PutAccountsIDParams contains all the parameters to send to the API endpoint
+/*
+PutAccountsIDParams contains all the parameters to send to the API endpoint
 for the put accounts ID operation typically these are written to a http.Request
 */
 type PutAccountsIDParams struct {

--- a/client/operations/put_accounts_id_responses.go
+++ b/client/operations/put_accounts_id_responses.go
@@ -47,7 +47,8 @@ func NewPutAccountsIDOK() *PutAccountsIDOK {
 	return &PutAccountsIDOK{}
 }
 
-/*PutAccountsIDOK handles this case with default header values.
+/*
+PutAccountsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutAccountsIDDefault(code int) *PutAccountsIDDefault {
 	}
 }
 
-/*PutAccountsIDDefault handles this case with default header values.
+/*
+PutAccountsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_apps_id_parameters.go
+++ b/client/operations/put_apps_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutAppsIDParamsWithHTTPClient(client *http.Client) *PutAppsIDParams {
 	}
 }
 
-/*PutAppsIDParams contains all the parameters to send to the API endpoint
+/*
+PutAppsIDParams contains all the parameters to send to the API endpoint
 for the put apps ID operation typically these are written to a http.Request
 */
 type PutAppsIDParams struct {

--- a/client/operations/put_apps_id_responses.go
+++ b/client/operations/put_apps_id_responses.go
@@ -47,7 +47,8 @@ func NewPutAppsIDOK() *PutAppsIDOK {
 	return &PutAppsIDOK{}
 }
 
-/*PutAppsIDOK handles this case with default header values.
+/*
+PutAppsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutAppsIDDefault(code int) *PutAppsIDDefault {
 	}
 }
 
-/*PutAppsIDDefault handles this case with default header values.
+/*
+PutAppsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_certificates_id_parameters.go
+++ b/client/operations/put_certificates_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutCertificatesIDParamsWithHTTPClient(client *http.Client) *PutCertifica
 	}
 }
 
-/*PutCertificatesIDParams contains all the parameters to send to the API endpoint
+/*
+PutCertificatesIDParams contains all the parameters to send to the API endpoint
 for the put certificates ID operation typically these are written to a http.Request
 */
 type PutCertificatesIDParams struct {

--- a/client/operations/put_certificates_id_responses.go
+++ b/client/operations/put_certificates_id_responses.go
@@ -47,7 +47,8 @@ func NewPutCertificatesIDOK() *PutCertificatesIDOK {
 	return &PutCertificatesIDOK{}
 }
 
-/*PutCertificatesIDOK handles this case with default header values.
+/*
+PutCertificatesIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutCertificatesIDDefault(code int) *PutCertificatesIDDefault {
 	}
 }
 
-/*PutCertificatesIDDefault handles this case with default header values.
+/*
+PutCertificatesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_databases_id_parameters.go
+++ b/client/operations/put_databases_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutDatabasesIDParamsWithHTTPClient(client *http.Client) *PutDatabasesIDP
 	}
 }
 
-/*PutDatabasesIDParams contains all the parameters to send to the API endpoint
+/*
+PutDatabasesIDParams contains all the parameters to send to the API endpoint
 for the put databases ID operation typically these are written to a http.Request
 */
 type PutDatabasesIDParams struct {

--- a/client/operations/put_databases_id_responses.go
+++ b/client/operations/put_databases_id_responses.go
@@ -47,7 +47,8 @@ func NewPutDatabasesIDOK() *PutDatabasesIDOK {
 	return &PutDatabasesIDOK{}
 }
 
-/*PutDatabasesIDOK handles this case with default header values.
+/*
+PutDatabasesIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutDatabasesIDDefault(code int) *PutDatabasesIDDefault {
 	}
 }
 
-/*PutDatabasesIDDefault handles this case with default header values.
+/*
+PutDatabasesIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_log_drains_id_parameters.go
+++ b/client/operations/put_log_drains_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutLogDrainsIDParamsWithHTTPClient(client *http.Client) *PutLogDrainsIDP
 	}
 }
 
-/*PutLogDrainsIDParams contains all the parameters to send to the API endpoint
+/*
+PutLogDrainsIDParams contains all the parameters to send to the API endpoint
 for the put log drains ID operation typically these are written to a http.Request
 */
 type PutLogDrainsIDParams struct {

--- a/client/operations/put_log_drains_id_responses.go
+++ b/client/operations/put_log_drains_id_responses.go
@@ -47,7 +47,8 @@ func NewPutLogDrainsIDOK() *PutLogDrainsIDOK {
 	return &PutLogDrainsIDOK{}
 }
 
-/*PutLogDrainsIDOK handles this case with default header values.
+/*
+PutLogDrainsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutLogDrainsIDDefault(code int) *PutLogDrainsIDDefault {
 	}
 }
 
-/*PutLogDrainsIDDefault handles this case with default header values.
+/*
+PutLogDrainsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_operations_id_parameters.go
+++ b/client/operations/put_operations_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutOperationsIDParamsWithHTTPClient(client *http.Client) *PutOperationsI
 	}
 }
 
-/*PutOperationsIDParams contains all the parameters to send to the API endpoint
+/*
+PutOperationsIDParams contains all the parameters to send to the API endpoint
 for the put operations ID operation typically these are written to a http.Request
 */
 type PutOperationsIDParams struct {

--- a/client/operations/put_operations_id_responses.go
+++ b/client/operations/put_operations_id_responses.go
@@ -47,7 +47,8 @@ func NewPutOperationsIDOK() *PutOperationsIDOK {
 	return &PutOperationsIDOK{}
 }
 
-/*PutOperationsIDOK handles this case with default header values.
+/*
+PutOperationsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutOperationsIDDefault(code int) *PutOperationsIDDefault {
 	}
 }
 
-/*PutOperationsIDDefault handles this case with default header values.
+/*
+PutOperationsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/client/operations/put_vhosts_id_parameters.go
+++ b/client/operations/put_vhosts_id_parameters.go
@@ -59,7 +59,8 @@ func NewPutVhostsIDParamsWithHTTPClient(client *http.Client) *PutVhostsIDParams 
 	}
 }
 
-/*PutVhostsIDParams contains all the parameters to send to the API endpoint
+/*
+PutVhostsIDParams contains all the parameters to send to the API endpoint
 for the put vhosts ID operation typically these are written to a http.Request
 */
 type PutVhostsIDParams struct {

--- a/client/operations/put_vhosts_id_responses.go
+++ b/client/operations/put_vhosts_id_responses.go
@@ -47,7 +47,8 @@ func NewPutVhostsIDOK() *PutVhostsIDOK {
 	return &PutVhostsIDOK{}
 }
 
-/*PutVhostsIDOK handles this case with default header values.
+/*
+PutVhostsIDOK handles this case with default header values.
 
 successful
 */
@@ -70,7 +71,8 @@ func NewPutVhostsIDDefault(code int) *PutVhostsIDDefault {
 	}
 }
 
-/*PutVhostsIDDefault handles this case with default header values.
+/*
+PutVhostsIDDefault handles this case with default header values.
 
 Error response. Often a 4xx or 5xx status code
 */

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,4 @@ require (
 	github.com/go-openapi/strfmt v0.19.4
 	github.com/go-openapi/swag v0.19.6
 	github.com/go-openapi/validate v0.19.5
-	github.com/mitchellh/go-homedir v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -124,7 +122,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This accomplishes a few things, mainly centered around deprecating ELB-based http endpoints, and the type `http_proxy_protocol` that was used for them. 

This client and our TF provide only create ALB-based http endpoints, and should have never created them as `http_proxy_protocol`, but rather `http`, as this change implements.

It this client an our TF provider couldn't import existing `type: "http"` endpoints, which all client _should_ create. We need to at least temporarily (until all vhost in the API are changed) accept both http and http_proxy_protocol. Solve this issue: https://github.com/aptible/terraform-provider-aptible/issues/179

Finally, I updated the user agent string so that instead of the generic `OpenAPI-Generator/1.0.0/go` we get `aptible/go-deploy/v0.5.5`

Then, i had to bump the go version, test tool versions to a version that support arm so i can test on my laptop, fix a decade's worth of whitespacing formatting errors, and remove a deprecated module that doesn't have support for typechecking in the linter...